### PR TITLE
fix Rank-Up-Magic Skip Force

### DIFF
--- a/script/c6958.lua
+++ b/script/c6958.lua
@@ -61,14 +61,15 @@ function c6958.activate(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 
-function c6958.cfilter(c)
+function c6958.cfilter(c,e,tp)
 	return c:IsSetCard(0xba) and c:IsType(TYPE_MONSTER) and c:IsAbleToRemoveAsCost()
+		and Duel.IsExistingMatchingCard(c6958.spfil,tp,LOCATION_GRAVE,0,1,c,e,tp)
 end
 function c6958.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsAbleToRemoveAsCost()
-		and Duel.IsExistingMatchingCard(c6958.cfilter,tp,LOCATION_GRAVE,0,1,nil) end
+		and Duel.IsExistingMatchingCard(c6958.cfilter,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-	local g=Duel.SelectMatchingCard(tp,c6958.cfilter,tp,LOCATION_GRAVE,0,1,1,nil)
+	local g=Duel.SelectMatchingCard(tp,c6958.cfilter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
 	g:AddCard(e:GetHandler())
 	Duel.Remove(g,POS_FACEUP,REASON_COST)
 end
@@ -78,6 +79,7 @@ end
 function c6958.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c6958.spfil(chkc,e,tp) end
 	if chk==0 then return Duel.IsExistingTarget(c6958.spfil,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectTarget(tp,c6958.spfil,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
 end


### PR DESCRIPTION
Fix: It can banish the only one XYZ monster that can be special summoned by it.
Btw, add a tip.
