### PR TITLE
fix Lunalight Crimson Fox

### DIFF
--- a/script/c6118.lua
+++ b/script/c6118.lua
@@ -5,7 +5,7 @@ function c6118.initial_effect(c)
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(6118,0))
 	e1:SetCategory(CATEGORY_ATKCHANGE)
-	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
 	e1:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DELAY+EFFECT_FLAG_CARD_TARGET)
 	e1:SetCode(EVENT_TO_GRAVE)
 	e1:SetCondition(c6118.atkcon)
@@ -48,7 +48,7 @@ function c6118.atkop(e,tp,eg,ep,ev,re,r,rp)
 end
 
 function c6118.filter(c,tp)
-	return c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) and c:IsSetCard(0xe1)
+	return c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) and c:IsFaceup() and c:IsSetCard(0xe1)
 end
 function c6118.condition(e,tp,eg,ep,ev,re,r,rp)
 	if not re:IsHasProperty(EFFECT_FLAG_CARD_TARGET) then return false end


### PR DESCRIPTION
Fix: It's atk to 0 effect should be opitional.
Fix: It's negate effect shouldn't be able to active when face-down Lunalight monster was targeted.
