### PR TITLE
Update lflist.conf

### DIFF
--- a/lflist.conf
+++ b/lflist.conf
@@ -1,15 +1,13 @@
-#[2016.4 TCG ][2016.4 OCG][Traditional][Anime]
-!2016.4 TCG 
+?#[2016.4 TCG][2016.4 OCG][2016.4 Traditional][2016.4 Worlds][2016.4 Anime]
+!2016.4 TCG
 #forbidden
-31222701 0 --Wavering Eyes
-67616300 0 --Chicken Game
 07563579 0 --Ｅｍヒグルミ
 68819554 0 --Ｅｍダメージ・ジャグラー
 18326736 0 --星守の騎士 プトレマイオス
 27279764 0 --アポクリフォート・キラー
 20663556 0 --イレカエル
 20366274 0 --エルシャドール・ネフィリム
-40044918 0 --E·HERO エアーマン
+40044918 0 --E・HERO エアーマン
 53804307 0 --焔征竜－ブラスター
 44910027 0 --ヴィクトリー・ドラゴン
 82301904 0 --混沌帝龍 －終焉の使者－
@@ -19,14 +17,13 @@
 26202165 0 --クリッター
 78010363 0 --黒き森のウィッチ
 34124316 0 --サイバーポッド
-63519819 0 --サウザンド·アイズ·サクリファイス
 50321796 0 --氷結界の龍 ブリューナク
 81122844 0 --発条空母ゼンマイティ
 21593977 0 --処刑人－マキュラ
 56570271 0 --D－HERO ディスクガイ
-69015963 0 --デビル·フランケン
+69015963 0 --デビル・フランケン
 33184167 0 --同族感染ウィルス
-54719828 0 --No.16 色の支配者ショック·ルーラー
+54719828 0 --No.16 色の支配者ショック・ルーラー
 90307777 0 --影霊衣の術士 シュリット
 34086406 0 --ラヴァルバル・チェイン
 26400609 0 --瀑征竜－タイダル
@@ -64,7 +61,7 @@
 70828912 0 --早すぎた埋葬
 34906152 0 --マスドライバー
 46448938 0 --魔導書の神判
-77565204 0 --未来融合－フューチャー·フュージョン
+77565204 0 --未来融合－フューチャー・フュージョン
 27970830 0 --六武の門
 46411259 0 --突然変異
 85602018 0 --遺言状
@@ -74,41 +71,37 @@
 41420027 0 --神の宣告
 57585212 0 --自爆スイッチ
 03280747 0 --第六感
-64697231 0 --ダスト·シュート
+64697231 0 --ダスト・シュート
 35316708 0 --刻の封印
 80604091 0 --血の代償
 28566710 0 --ラストバトル！
+18326736 0 --星守の騎士 プトレマイオス
+67616300 0 --Chicken Race
+31222701 0 --Wavering Eyes
 #limit
-72714461 1 --慧眼の魔術師
-70368879 1 --Upstart Goblin
-58577036 1 --Reasoning
-14733538 1 --Draco Face-Off
-18239909 1 --Ignister Prominence, The Blasting Dracoslayer
-63519819 1 --Thousand-Eyes Restrict
-17412721 1 --Elder Entity Norden
 40318957 1 --ＥＭドクロバット・ジョーカー
 17330916 1 --ＥＭモンキーボード
 92746535 1 --竜剣士ラスターＰ
 85103922 1 --アーティファクト－モラルタ
-64034255 1 --A·ジェネクス·バードマン
-45222299 1 --イビリチュア·ガストクラーケ
-11877465 1 --イビリチュア·マインドオーガス
-99177923 1 --インフェルニティ·デーモン
+64034255 1 --A・ジェネクス・バードマン
+45222299 1 --イビリチュア・ガストクラーケ
+11877465 1 --イビリチュア・マインドオーガス
+99177923 1 --インフェルニティ・デーモン
 68184115 1 --甲虫装機 ダンセル
 69207766 1 --甲虫装機 ホーネット
-72989439 1 --カオス·ソルジャー －開闢の使者－
+72989439 1 --カオス・ソルジャー －開闢の使者－
 65518099 1 --クリフォート・ツール
-12580477 1 --サンダー·ボルト
+12580477 1 --サンダー・ボルト
 78868119 1 --深海のディーヴァ
 48063985 1 --聖霊獣騎 カンナホーク
 59297550 1 --ゼンマイマジシャン
-65192027 1 --ダーク·アームド·ドラゴン
+65192027 1 --ダーク・アームド・ドラゴン
 15341821 1 --ダンディライオン
-90953320 1 --TG ハイパー·ライブラリアン
+90953320 1 --TG ハイパー・ライブラリアン
 26674724 1 --ブリューナクの影霊衣
 52687916 1 --氷結界の龍 トリシューラ
 16226786 1 --深淵の暗殺者
-80344569 1 --N·グラン·モール
+80344569 1 --N・グラン・モール
 70583986 1 --氷結界の虎王ドゥローレン
 33396948 1 --封印されしエクゾディア
 07902349 1 --封印されし者の左腕
@@ -119,7 +112,7 @@
 10802915 1 --魔界発現世行きデスガイド
 71564252 1 --ライオウ
 85138716 1 --レスキューラビット
-88264978 1 --レッドアイズ·ダークネスメタルドラゴン
+88264978 1 --レッドアイズ・ダークネスメタルドラゴン
 48976825 1 --異次元からの埋葬
 89463537 1 --ユニコールの影霊衣
 33782437 1 --一時休戦
@@ -141,7 +134,7 @@
 20758643 1 --彼岸の悪鬼 グラバースニッチ
 43040603 1 --モンスターゲート
 23171610 1 --リミッター解除
-02295440 1 --ワン·フォー·ワン
+02295440 1 --ワン・フォー・ワン
 09059700 1 --インフェルニティ・バリア
 05851097 1 --虚無空間
 84749824 1 --神の警告
@@ -154,12 +147,16 @@
 83555666 1 --破壊輪
 17078030 1 --光の護封壁
 30241314 1 --マクロコスモス
-32723153 1 --マジカル·エクスプロージョン
+32723153 1 --マジカル・エクスプロージョン
 54974237 1 --闇のデッキ破壊ウイルス
+72714461 1 --慧眼の魔術師
+17412721 1 --旧神ノーデン
+63519819 1 --サウザンド・アイズ・サクリファイス
+18239909 1 --Ignister Prominence, The Blasting Dracoslayer
+14733538 1 --Draco Face-Off
+58577036 1 --Reasoning
+70368879 1 --Upstart Goblin
 #semi limit
-67723438 2 --Emergency Teleport
-01475311 2 --闇の誘惑
-14943837 2 --デブリ·ドラゴン
 37742478 2 --オネスト
 85087012 2 --カードガンナー
 74311226 2 --海皇の竜騎隊
@@ -167,18 +164,21 @@
 28297833 2 --ネクロフェイス
 94886282 2 --光の援軍
 57143342 2 --彼岸の悪鬼 ガトルホッグ
-53129443 2 --ブラック·ホール
+53129443 2 --ブラック・ホール
 62265044 2 --竜の渓谷
 91623717 2 --連鎖爆撃
 29843091 2 --おジャマトリオ
 36468556 2 --停戦協定
+67723438 2 --Emergency Teleport
+01475311 2 --闇の誘惑
+14943837 2 --デブリ・ドラゴン
 
 !2016.4 OCG
 #forbidden
 17178486 0 --Life Equalizer
 34086406 0 --ラヴァルバル・チェイン
 17330916 0 --Performapal Monkeyboard
-54719828 0 --No.16 色の支配者ショック·ルーラー
+54719828 0 --No.16 色の支配者ショック・ルーラー
 68819554 0 --Emダメージ・ジャグラー
 07563579 0 --Emヒグルミ
 20663556 0 --イレカエル
@@ -189,9 +189,9 @@
 17412721 0 --旧神ノーデン
 26202165 0 --クリッター
 78010363 0 --黒き森のウィッチ
-07391448 0 --ゴヨウ·ガーディアン
+07391448 0 --ゴヨウ・ガーディアン
 34124316 0 --サイバーポッド
-63519819 0 --サウザンド·アイズ·サクリファイス
+63519819 0 --サウザンド・アイズ・サクリファイス
 21593977 0 --処刑人－マキュラ
 31560081 0 --聖なる魔術師
 16923472 0 --ゼンマイハンター
@@ -216,7 +216,7 @@
 45986603 0 --強奪
 55144522 0 --強欲な壺
 04031928 0 --心変わり
-12580477 0 --サンダー·ボルト
+12580477 0 --サンダー・ボルト
 23557835 0 --次元融合
 57953380 0 --生還の宝札
 87910978 0 --洗脳－ブレインコントロール
@@ -227,14 +227,14 @@
 42703248 0 --ハリケーン
 34906152 0 --マスドライバー
 46448938 0 --魔導書の神判
-77565204 0 --未来融合－フューチャー·フュージョン
+77565204 0 --未来融合－フューチャー・フュージョン
 46411259 0 --突然変異
 85602018 0 --遺言状
 27174286 0 --異次元からの帰還
 93016201 0 --王宮の弾圧
 61740673 0 --王宮の勅命
 03280747 0 --第六感
-64697231 0 --ダスト·シュート
+64697231 0 --ダスト・シュート
 80604091 0 --血の代償
 35316708 0 --刻の封印
 28566710 0 --ラストバトル！
@@ -243,19 +243,19 @@
 47075569 1 --Performapal Pendulum Sorcerer
 40318957 1 --ＥＭドクロバット・ジョーカー
 85103922 1 --アーティファクト－モラルタ
-64034255 1 --A·ジェネクス·バードマン
+64034255 1 --A・ジェネクス・バードマン
 68184115 1 --甲虫装機 ダンセル
-40044918 1 --E·HERO エアーマン
+40044918 1 --E・HERO エアーマン
 50720316 1 --E・HERO シャドー・ミスト
-72989439 1 --カオス·ソルジャー －開闢の使者－
+72989439 1 --カオス・ソルジャー －開闢の使者－
 72714461 1 --慧眼の魔術師
 06602300 1 --重爆撃禽 ボム・フェネクス
 28985331 1 --終末の騎士
 00423585 1 --召喚僧サモンプリースト
 78868119 1 --深海のディーヴァ
-65192027 1 --ダーク·アームド·ドラゴン
+65192027 1 --ダーク・アームド・ドラゴン
 15341821 1 --ダンディライオン
-90953320 1 --TG ハイパー·ライブラリアン
+90953320 1 --TG ハイパー・ライブラリアン
 16226786 1 --深淵の暗殺者
 90307777 1 --影霊衣の術士 シュリット
 28297833 1 --ネクロフェイス
@@ -270,7 +270,7 @@
 41386308 1 --マスマティシャン
 33508719 1 --メタモルポット
 89463537 1 --ユニコールの影霊衣
-88264978 1 --レッドアイズ·ダークネスメタルドラゴン
+88264978 1 --レッドアイズ・ダークネスメタルドラゴン
 48976825 1 --異次元からの埋葬
 33782437 1 --一時休戦
 66957584 1 --インフェルニティガン
@@ -288,18 +288,18 @@
 67169062 1 --貪欲な壺
 97211663 1 --影霊衣の反魂術
 18144506 1 --ハーピィの羽根帚
-53129443 1 --ブラック·ホール
+53129443 1 --ブラック・ホール
 15854426 1 --霞の谷の神風
 23171610 1 --リミッター解除
 62265044 1 --竜の渓谷
-02295440 1 --ワン·フォー·ワン
+02295440 1 --ワン・フォー・ワン
 84749824 1 --神の警告
 41420027 1 --神の宣告
 05851097 1 --虚無空間
 36468556 1 --停戦協定
 83555666 1 --破壊輪
 17078030 1 --光の護封壁
-32723153 1 --マジカル·エクスプロージョン
+32723153 1 --マジカル・エクスプロージョン
 26202165 1 --Sangan
 84764038 1 --Scarm, Malebranche of the Burning Abyss
 10802915 1 --Tour Guide From the Underworld
@@ -317,7 +317,7 @@
 14733538 1 --Draco Face-Off
 #semi limit
 27770341 2 --超再生能力
-45222299 2 --イビリチュア·ガストクラーケ
+45222299 2 --イビリチュア・ガストクラーケ
 74311226 2 --海皇の竜騎隊
 65518099 2 --クリフォート・ツール
 70583986 2 --氷結界の虎王ドゥローレン
@@ -328,378 +328,187 @@
 27970830 2 --六武の門
 77505534 2 --堕ち影の蠢き
 
-
-!Traditional
+!2016.4 Traditional
 #forbidden
 #limit
-27279764 1 --Apoqliphort Towers
-53804307 1 --Blaster, Dragon Ruler of Infernos
-82301904 1 --Chaos Emperor Dragon - Envoy of the End
-34124316 1 --Cyber Jar
-69015963 1 --Cyber-Stein
-40737112 1 --Dark Magician of Chaos
-56570271 1 --Destiny HERO - Disk Commander
-50720316 1 --Elemental HERO Shadow Mist
-40044918 1 --Elemental HERO Stratos
-78706415 1 --Fiber Jar
-93369354 1 --Fishborg Blaster
-67441435 1 --Glow-Up Bulb
-20758643 1 --Graff, Malebranche of the Burning Abyss
-21593977 1 --Makyura the Destructor
-34206604 1 --Magical Scientist
-31560081 1 --Magician of Faith
-96782886 1 --Mind Master
-33508719 1 --Morphing Jar
-79106360 1 --Morphing Jar #2
-90411554 1 --Redox, Dragon Ruler of Boulders
-14878871 1 --Rescue Cat
-89399912 1 --Tempest, Dragon Ruler of Storms
-26400609 1 --Tidal, Dragon Ruler of Waterfalls
-33184167 1 --Tribe-Infecting Virus
-44910027 1 --Victory Dragon
-16923472 1 --Wind-Up Hunter
-78010363 1 --Witch of the Black Forest
-26202165 1 --Sangan
-20663556 1 --Substitoad
-03078576 1 --Yata-Garasu
-20366274 1 --El Shaddoll Construct
-17412721 1 --Elder Entity Norden
-48063985 1 --Ritual Beast Ulti-Cannahawk
-63519819 1 --Thousand-Eyes Restrict
-50321796 1 --Brionac, Dragon of the Ice Barrier
-07391448 1 --Goyo Guardian
-46772449 1 --Evilswarm Exciton Knight
-34086406 1 --Lavalval Chain
-54719828 1 --Number 16: Shock Master
-18326736 1 --Tellarknight Ptolemaeus
-81122844 1 --Wind-Up Carrier Zenmaity
-87910978 1 --Brain Control
-69243953 1 --Butterfly Dagger - Elma
-72892473 1 --Card Destruction
-57953380 1 --Card of Safe Return
-04031928 1 --Change of Heart
-60682203 1 --Cold Wave
-17375316 1 --Confiscation
-44763025 1 --Delinquent Duo
-23557835 1 --Dimension Fusion
-77565204 1 --Future Fusion
-27970830 1 --Gateway of the Six
-42703248 1 --Giant Trunade
-79571449 1 --Graceful Charity
-18144506 1 --Harpie's Feather Duster
-19613556 1 --Heavy Storm
-85602018 1 --Last Will
-34906152 1 --Mass Driver
-46411259 1 --Metamorphosis
-41482598 1 --Mirage of Nightmare
-83764718 1 --Monster Reborn
-74191942 1 --Painful Choice
-67169062 1 --Pot of Avarice
-55144522 1 --Pot of Greed
-70828912 1 --Premature Burial
-12580477 1 --Raigeki
-45986603 1 --Snatch Steal
-46448938 1 --Spellbook of Judgment
-48130397 1 --Super Polymerization
-27770341 1 --Super Rejuvenation
-42829885 1 --The Forceful Sentry
-28566710 1 --Last Turn
-61740673 1 --Imperial Order
-27174286 1 --Return from the Different Dimension
-93016201 1 --Royal Oppression
-57585212 1 --Self-Destruct Button
-03280747 1 --Sixth Sense
-41420027 1 --Solemn Judgment
-35316708 1 --Time Seal
-64697231 1 --Trap Dustshoot
-80604091 1 --Ultimate Offering
-100000000 1 --Chaos End Ruler -Ruler of the Beginning and the End-
-41181774  1 --Earthbound Immortal Wiraqocha Rasca
-10000000  1 --Obelisk the Tormentor
-511000787 1 --Rose Shaman
-10000010  1 --The Winged Dragon of Ra
-100000020 1 --After Glow
-170000119 1 --Blasting Vein
-511000691 1 --Card Exchange
-511000207 1 --Card of Burial Magic
-511000752 1 --Card of Compensation
-511001149 1 --Card of Demise
-511000784 1 --Card of Desperation
-42664989  1 --Card of Sanctity
-511000204 1 --Card of Spell Containment
-511000654 1 --Card of Variation
-800000002 1 --Chameleon Colors
-511000167 1 --Dark Wall of Wind
-810000021 1 --Deepest Impact
-511000471 1 --Drawber
-810000082 1 --Giant Flood
-511000554 1 --Heaven's Lost Property
-100000083 1 --Illusion Gate
-511000504 1 --Magician's Archive
-85852291  1 --Magical Mallet
-511001133 1 --Mischief of the Time Goddess
-93108433  1 --Monster Recovery
-511000461 1 --Monster Replace
-40703222  1 --Multiply
-511000399 1 --Negative Energy Generator
-511000270 1 --Nibelung's Treasure
-100000247 1 --Philosopher's Stone - Sabatiel
-34016756  1 --Riryoku
-511001142 1 --Roll of Fate
-54447022  1 --Soul Charge
-511000171 1 --Spell Sanctuary
-511000506 1 --Spellbook Inside the Pot
-100000186 1 --Sphere Field
-511000180 1 --Surprise Attack from Beyond
-170000117 1 --Time Fusion
-511000091 1 --Turn Jump
-511000084 1 --White Night Fort
-200000004 1 --Winning Formula
-511001119 1 --Deck Destruction Virus
-511000464 1 --Domain of the Dark Ruler
-800000000 1 --Forceful Deal
-61705417  1 --Graverobber
-511000618 1 --Insightful Cards of Reversal
-37520316  1 --Mind Control
-511000481 1 --Mirror of Duality
-511001143 1 --Power Balance
-511001505 1 --Rebirth Tablet
-511001499 1 --Take One Chance
-28985331 1 --Armageddon Knight
-85103922 1 --Artifact Moralltach
-72989439 1 --Black Luster Soldier - Envoy of the Beginning
-15341821 1 --Dandylion
-65192027 1 --Dark Armed Dragon
-14943837 1 --Debris Dragon
-78868119 1 --Deep Sea Diva
-33396948 1 --Exodia the Forbidden One
-64034255 1 --Genex Ally Birdman
-99177923 1 --Infernity Archfiend
-72714461 1 --Insight Magician
-68184115 1 --Inzektor Dragonfly
-69207766 1 --Inzektor Hornet
-07902349 1 --Left Arm of the Forbidden One
-44519536 1 --Left Leg of the Forbidden One
-41386308 1 --Mathematician
-28297833 1 --Necroface
-80344569 1 --Neo-Spacian Grand Mole
-16226786 1 --Night Assailant
-65518099 1 --Qliphort Scout
-88264978 1 --Red-Eyes Darkness Metal Dragon
-85138716 1 --Rescue Rabbit
-70903634 1 --Right Arm of the Forbidden One
-08124921 1 --Right Leg of the Forbidden One
-90307777 1 --Shurit, Strategist of the Nekroz
-91110378 1 --Star Seraph Sovereign
-00423585 1 --Summoner Monk
-71564252 1 --Thunder King Rai-Oh
-10802915 1 --Tour Guide From the Underworld
-59297550 1 --Wind-Up Magician
-06602300 1 --Blaze Fenix, the Burning Bombardment Bird
-45222299 1 --Evigishki Gustkraken
-11877465 1 --Evigishki Mind Augus
-26674724 1 --Nekroz of Brionac
-89463537 1 --Nekroz of Unicore
-70583986 1 --Dewloren, Tiger King of the Ice Barrier
-90953320 1 --T.G. Hyper Librarian
-52687916 1 --Trishula, Dragon of the Ice Barrier
-01475311 1 --Allure of Darkness
-14087893 1 --Book of Moon
-48976825 1 --Burial From a Different Dimension
-53129443 1 --Dark Hole
-81674782 1 --Dimensional Fissure
-15854426 1 --Divine Wind of Mist Valley
-62265044 1 --Dragon Ravine
-06417578 1 --El Shaddoll Fusion
-95308449 1 --Final Countdown
-81439173 1 --Foolish Burial
-75500286 1 --Gold Sarcophagus
-66957584 1 --Infernity Launcher
-23171610 1 --Limiter Removal
-43040603 1 --Monster Gate
-97211663 1 --Nekroz Cycle
-33782437 1 --One Day of Peace
-02295440 1 --One for One
-96729612 1 --Preparation of Rites
-23701465 1 --Primal Seed
-32807846 1 --Reinforcement of the Army
-74845897 1 --Rekindling
-72405967 1 --Royal Tribute
-17639150 1 --Saqlifice
-45305419 1 --Symbol of Heritage
-29401950 1 --Bottomless Trap Hole
-36468556 1 --Ceasefire
-94192409 1 --Compulsory Evacuation Device
-57728570 1 --Crush Card Virus
-54974237 1 --Eradicator Epidemic Virus
-09059700 1 --Infernity Barrier
-30241314 1 --Macro Cosmos
-32723153 1 --Magical Explosion
-83555666 1 --Ring of Destruction
-82732705 1 --Skill Drain
-84749824 1 --Solemn Warning
-73599290 1 --Soul Drain
-53582587 1 --Torrential Tribute
-05851097 1 --Vanity's Emptiness
-17078030 1 --Wall of Revealing Light
-511001131 1 --Clone Dragon
-511000585 1 --Level Jar
-67098114  1 --Loki, Lord of the Aesir
-100000008 1 --Michion, the Timelord
-93483212  1 --Odin, Father of the Aesir
-21208154  1 --The Wicked Avatar
-62180201  1 --The Wicked Dreadroot
-57793869  1 --The Wicked Eraser
-30604579  1 --Thor, Lord of the Aesir
-6007213   1 --Uria, Lord of Searing Flames
-810000032 1 --Depth Eruption
-511000598 1 --Fallout
-110000102 1 --Living Fossil
-511000276 1 --Numeron Direct
-500000149 1 --Soul-Binding Gate
-62499965  1 --Z-ONE
-110000099 1 --Cursed Prison
-100000565 1 --Freezing Dance
-511000036 1 --Jurassic Impact
-100000117 1 --Life Force
-810000002 1 --Dark Spell Regeneration
-511000418 1 --Beckon to Darkness
-500000147 1 --École de Zone
-511000443 1 --Path to Destiny
-95000000 1 --Boss Duel
-95000001 1 --Darkness Outsider/Boss Duel
-95000002 1 --Darkness Neosphere/Boss Duel
-95000003 1 --Darkness/Boss Duel
-95000004 1 --Infinity/Boss Duel
-95000005 1 --Zero/Boss Duel
-95000006 1 --Darkness 1/Boss Duel
-95000007 1 --Darkness 2/Boss Duel
-95000008 1 --Darkness 3/Boss Duel
-95000009 1 --Toon Gemini Elf/Boss Duel
-95000010 1 --Toon Masked Sorcerer/Boss Duel
-95000011 1 --Toon Summoned Skull/Boss Duel
-95000012 1 --Toon World/Boss Duel
-95000013 1 --Comic Hand/Boss Duel
-95000014 1 --Relinquished/Boss Duel
-95000015 1 --Mimicat/Boss Duel
-95000016 1 --Toon Briefcase/Boss Duel
-95000017 1 --Numeron Callin/Boss Duel
-95000022 1 --Number C1:Numeron Chaos Gate Shunya/Boss Duel
-95000023 1 --Numeron Network/Boss Duel
-95000024 1 --Numeron Chaos Ritual/Boss Duel
-95000025 1 --Number C1000: Numerronius/Boss Duel
-95000026 1 --Number iC1000: Numerronius Numerronia/Boss Duel
-95000027 1 --Numeron Xyz Revision/Boss Duel
-95000028 1 --Numeron Spell Revision/Boss Duel
-95000029 1 --Nonexistence/Boss Duel
-95000030 1 --Michion, the Timelord/Boss Duel
-95000033 1 --Gabrion, the Timelord/Boss Duel
-95000036 1 --Sandaion, the Timelord/Boss Duel
-95000037 1 --Endless Emptiness/Boss Duel
-95000038 1 --Lazion, the Timelord/Boss Duel
-95000041 1 --Infinite Light/Boss Duel
-95000042 1 --Sephylon, the Ultimate Timelord/Boss Duel
-29654737 1 --Amazoness Chain Master
-19028307 1 --Beast Machine King Barbaros Ür
-110000110 1 --Big Bang Blow
-100000704 1 --Darkness Outsider
-100000700 1 --Darkness Seed
-511000585 1 --Level Jar
-170000171 1 --Orichalcos Gigas
-31709826 1 --Revival Jam
-511000251 1 --Valkyrie of the Nordic Ascendant
-10000020 1 --Slifer the Sky Dragon
-511001515 1 --Sniping Hazy Type-0
-511001658 1 --Stardust Chronicle Spark Dragon
-98045062 1 --Enemy Controller
-51100561 1 --Get Your Game On!
-511000435 1 --Golden Castle of Stromberg
-511000970 1 --Mirror Prison
-511001453 1 --Misdirection Wing
-511001417 1 --Water of Life
-511001125 1 --Life Shaver
-511000866 1 --Xyz Trasure Ticket
-511001758 1 --Akashic Record
-511000729 1 --Berserk Mode
-511001186 1 --Contract with Don Thousand
-170000170 1 --Divine Serpent
-511001307 1 --Energy Drain
-17484499 1 --Exchange of the Spirit
-13893596 1 --Exodius the Ultimate Forbidden Lord
-511000814 1 --Extra Fusion
-511000672 1 --Fire Whip
-511001629 1 --Graveyard Rebound
-511001273 1 --Number 37: Hope Woven Dragon Spider Shark
-511000333 1 --Quick Rush
-511001582 1 --Performage Hurricane
-810000088 1 --Pillager
-83555666 1 --Ring of Destruction
-29762407 1 --Temple of the Kings
-511000736 1 --Wing Requital
-100000239 1 --Xyz Treasure
-511001726 1 --Ancient Gear Ultimate Hound Dog
-511000601 1 --Arcanatic Doomscythe
-81480460 1 --Barrel Dragon
-511000789 1 --Briar Transplant
-511000800 1 --Celestial Bell Tower
-511000992 1 --Circle of Terror
-511000407 1 --Curse Transfer
-32146097 1 --D/D Pandora
-100000274 1 --Destiny HERO - The Dark Angel
-511001207 1 --Draw Slime
-511001583 1 --Fortress of Prophecy
-100000474 1 --Fusion Birth
-511001627 1 --Galaxy Journey
-511000201 1 --Illusion Destruction
-511000988 1 --Masahiro the Dark Clown
-100000226 1 --Mirror Stage of Discipline
-511000544 1 --Mother Spider
-511001320 1 --Ninja Commando Kabuki
-06387204 1 --Number C6: Chronomaly Chaos Atlandis
-511001612 1 --Numbers Exist
-100000312 1 --Past Life
-110000104 1 --Psychic Armor Head
-45950291 1 --Rank-Up-Magic Astral Force
-511000829 1 --Re-Xyz
-100000470 1 --Soul Fusion
-511000809 1 --Spectral Ice Floe
-511001614 1 --Spirit Xyz Spark
-511001642 1 --Synchro Alliance
-511000920 1 --Spell Transfer
-100000478 1 --Ties of the Brethren
-511000551 1 --Treasures of the Dead
-511001172 1 --Underwater Snow Prison
-100000239 1 --Xyz Treasure
-810000022 1 --Zeta Reticulant
+07563579 1 --Ｅｍヒグルミ
+68819554 1 --Ｅｍダメージ・ジャグラー
+18326736 1 --星守の騎士 プトレマイオス
+27279764 1 --アポクリフォート・キラー
+20663556 1 --イレカエル
+20366274 1 --エルシャドール・ネフィリム
+40044918 1 --E・HERO エアーマン
+53804307 1 --焔征竜－ブラスター
+44910027 1 --ヴィクトリー・ドラゴン
+82301904 1 --混沌帝龍 －終焉の使者－
+79106360 1 --カオスポッド
+90411554 1 --巌征竜－レドックス
+08903700 1 --儀式魔人リリーサー
+26202165 1 --クリッター
+78010363 1 --黒き森のウィッチ
+34124316 1 --サイバーポッド
+50321796 1 --氷結界の龍 ブリューナク
+81122844 1 --発条空母ゼンマイティ
+21593977 1 --処刑人－マキュラ
+56570271 1 --D－HERO ディスクガイ
+69015963 1 --デビル・フランケン
+33184167 1 --同族感染ウィルス
+54719828 1 --No.16 色の支配者ショック・ルーラー
+90307777 1 --影霊衣の術士 シュリット
+34086406 1 --ラヴァルバル・チェイン
+26400609 1 --瀑征竜－タイダル
+46772449 1 --励輝士 ヴェルズビュート
+78706415 1 --ファイバーポッド
+93369354 1 --フィッシュボーグ－ガンナー
+34206604 1 --魔導サイエンティスト
+33508719 1 --メタモルポット
+96782886 1 --メンタルマスター
+03078576 1 --八汰烏
+89399912 1 --嵐征竜－テンペスト
+14878871 1 --レスキューキャット
+41482598 1 --悪夢の蜃気楼
+44763025 1 --いたずら好きな双子悪魔
+19613556 1 --大嵐
+17375316 1 --押収
+74191942 1 --苦渋の選択
+42829885 1 --強引な番兵
+45986603 1 --強奪
+55144522 1 --強欲な壺
+04031928 1 --心変わり
+23557835 1 --次元融合
+83764718 1 --死者蘇生
+57953380 1 --生還の宝札
+87910978 1 --洗脳－ブレインコントロール
+60682203 1 --大寒波
+67169062 1 --貪欲な壺
+27770341 1 --超再生能力
+69243953 1 --蝶の短剣－エルマ
+72892473 1 --手札抹殺
+79571449 1 --天使の施し
+48130397 1 --超融合
+42703248 1 --ハリケーン
+18144506 1 --ハーピィの羽根帚
+70828912 1 --早すぎた埋葬
+34906152 1 --マスドライバー
+46448938 1 --魔導書の神判
+77565204 1 --未来融合－フューチャー・フュージョン
+27970830 1 --六武の門
+46411259 1 --突然変異
+85602018 1 --遺言状
+27174286 1 --異次元からの帰還
+61740673 1 --王宮の勅命
+93016201 1 --王宮の弾圧
+41420027 1 --神の宣告
+57585212 1 --自爆スイッチ
+03280747 1 --第六感
+64697231 1 --ダスト・シュート
+35316708 1 --刻の封印
+80604091 1 --血の代償
+28566710 1 --ラストバトル！
+18326736 1 --星守の騎士 プトレマイオス
+67616300 1 --Chicken Game
+31222701 1 --Wavering Eyes
+40318957 1 --ＥＭドクロバット・ジョーカー
+17330916 1 --ＥＭモンキーボード
+92746535 1 --竜剣士ラスターＰ
+85103922 1 --アーティファクト－モラルタ
+64034255 1 --A・ジェネクス・バードマン
+45222299 1 --イビリチュア・ガストクラーケ
+11877465 1 --イビリチュア・マインドオーガス
+99177923 1 --インフェルニティ・デーモン
+68184115 1 --甲虫装機 ダンセル
+69207766 1 --甲虫装機 ホーネット
+72989439 1 --カオス・ソルジャー －開闢の使者－
+65518099 1 --クリフォート・ツール
+12580477 1 --サンダー・ボルト
+78868119 1 --深海のディーヴァ
+48063985 1 --聖霊獣騎 カンナホーク
+59297550 1 --ゼンマイマジシャン
+65192027 1 --ダーク・アームド・ドラゴン
+15341821 1 --ダンディライオン
+90953320 1 --TG ハイパー・ライブラリアン
+26674724 1 --ブリューナクの影霊衣
+52687916 1 --氷結界の龍 トリシューラ
+16226786 1 --深淵の暗殺者
+80344569 1 --N・グラン・モール
+70583986 1 --氷結界の虎王ドゥローレン
+33396948 1 --封印されしエクゾディア
+07902349 1 --封印されし者の左腕
+70903634 1 --封印されし者の右腕
+44519536 1 --封印されし者の左足
+08124921 1 --封印されし者の右足
+41386308 1 --マスマティシャン
+10802915 1 --魔界発現世行きデスガイド
+71564252 1 --ライオウ
+85138716 1 --レスキューラビット
+88264978 1 --レッドアイズ・ダークネスメタルドラゴン
+48976825 1 --異次元からの埋葬
+89463537 1 --ユニコールの影霊衣
+33782437 1 --一時休戦
+66957584 1 --インフェルニティガン
+72405967 1 --王家の生け贄
+81439173 1 --おろかな埋葬
+06417578 1 --神の写し身との接触
+96729612 1 --儀式の準備
+45305419 1 --継承の印
+17639150 1 --機殻の生贄
+95308449 1 --終焉のカウントダウン
+74845897 1 --真炎の爆発
+37520316 1 --精神操作
+54447022 1 --ソウル・チャージ
+14087893 1 --月の書
+81674782 1 --次元の裂け目
+75500286 1 --封印の黄金櫃
+15854426 1 --霞の谷の神風
+20758643 1 --彼岸の悪鬼 グラバースニッチ
+43040603 1 --モンスターゲート
+23171610 1 --リミッター解除
+02295440 1 --ワン・フォー・ワン
+09059700 1 --インフェルニティ・バリア
+05851097 1 --虚無空間
+84749824 1 --神の警告
+94192409 1 --強制脱出装置
+53582587 1 --激流葬
+82732705 1 --スキルドレイン
+32807846 1 --増援
+73599290 1 --ソウルドレイン
+29401950 1 --奈落の落とし穴
+83555666 1 --破壊輪
+17078030 1 --光の護封壁
+30241314 1 --マクロコスモス
+32723153 1 --マジカル・エクスプロージョン
+54974237 1 --闇のデッキ破壊ウイルス
+72714461 1 --慧眼の魔術師
+17412721 1 --旧神ノーデン
+63519819 1 --サウザンド・アイズ・サクリファイス
+18239909 1 --Ignister Prominence, The Blasting Dracoslayer
+14733538 1 --Draco Face-Off
+58577036 1 --Reasoning
+70368879 1 --Upstart Goblin
 #semi limit
-74311226 2 --Atlantean Dragoons
-85087012 2 --Card Trooper
-57143342 2 --Cir, Malebranche of the Burning Abyss
-09411399 2 --Destiny HERO - Malicious
-37742478 2 --Honest
-16404809 2 --Kuribandit
-22446869 2 --Mermail Abyssteus
-92826944 2 --Mezuki
-10028593 2 --Reborn Tengu
-98777036 2 --Tragoedia
-46052429 2 --Advanced Ritual Art
-91623717 2 --Chain Strike
-94886282 2 --Charge of the Light Brigade
-41620959 2 --Dragon Shrine
-29843091 2 --Ojama Trio
-77505534 2 --Sinister Shadow Games
-511000494 2 --Effect Shut
-511001459 2 --Clear Effector
-511001821 2 --Necroid Synchro
+37742478 2 --オネスト
+85087012 2 --カードガンナー
+74311226 2 --海皇の竜騎隊
+00423585 2 --召喚僧サモンプリースト
+28297833 2 --ネクロフェイス
+94886282 2 --光の援軍
+57143342 2 --彼岸の悪鬼 ガトルホッグ
+53129443 2 --ブラック・ホール
+62265044 2 --竜の渓谷
+91623717 2 --連鎖爆撃
+29843091 2 --おジャマトリオ
+36468556 2 --停戦協定
+67723438 2 --Emergency Teleport
+01475311 2 --闇の誘惑
+14943837 2 --デブリ・ドラゴン
 
-!Anime
+!2016.4 Worlds
 #forbidden
 27279764 0 --Apoqliphort Towers
 53804307 0 --Blaster, Dragon Ruler of Infernos
 82301904 0 --Chaos Emperor Dragon - Envoy of the End
 34124316 0 --Cyber Jar
 69015963 0 --Cyber-Stein
-40737112 0 --Dark Magician of Chaos
 56570271 0 --Destiny HERO - Disk Commander
 08903700 0 --Djinn Releaser of Rituals
 40044918 0 --Elemental HERO Stratos
@@ -711,6 +520,7 @@
 96782886 0 --Mind Master
 33508719 0 --Morphing Jar
 79106360 0 --Morphing Jar #2
+17330916 0 --Performapal Monkeyboard
 90411554 0 --Redox, Dragon Ruler of Boulders
 14878871 0 --Rescue Cat
 89399912 0 --Tempest, Dragon Ruler of Storms
@@ -725,7 +535,6 @@
 03078576 0 --Yata-Garasu
 20366274 0 --El Shaddoll Construct
 17412721 0 --Elder Entity Norden
-63519819 0 --Thousand-Eyes Restrict
 50321796 0 --Brionac, Dragon of the Ice Barrier
 07391448 0 --Goyo Guardian
 46772449 0 --Evilswarm Exciton Knight
@@ -738,6 +547,7 @@
 72892473 0 --Card Destruction
 57953380 0 --Card of Safe Return
 04031928 0 --Change of Heart
+67616300 0 --Chicken Game
 60682203 0 --Cold Wave
 17375316 0 --Confiscation
 44763025 0 --Delinquent Duo
@@ -749,6 +559,7 @@
 18144506 0 --Harpie's Feather Duster
 19613556 0 --Heavy Storm
 85602018 0 --Last Will
+17178486 0 --Life Equalizer
 34906152 0 --Mass Driver
 46411259 0 --Metamorphosis
 41482598 0 --Mirage of Nightmare
@@ -763,8 +574,9 @@
 48130397 0 --Super Polymerization
 27770341 0 --Super Rejuvenation
 42829885 0 --The Forceful Sentry
-28566710 0 --Last Turn
+31222701 0 --Wavering Eyes
 61740673 0 --Imperial Order
+28566710 0 --Last Turn
 27174286 0 --Return from the Different Dimension
 93016201 0 --Royal Oppression
 57585212 0 --Self-Destruct Button
@@ -773,12 +585,142 @@
 35316708 0 --Time Seal
 64697231 0 --Trap Dustshoot
 80604091 0 --Ultimate Offering
+#limit
+28985331 1 --Armageddon Knight
+85103922 1 --Artifact Moralltach
+72989439 1 --Black Luster Soldier - Envoy of the Beginning
+15341821 1 --Dandylion
+65192027 1 --Dark Armed Dragon
+78868119 1 --Deep Sea Diva
+50720316 1 --Elemental HERO Shadow Mist
+33396948 1 --Exodia the Forbidden One
+64034255 1 --Genex Ally Birdman
+20758643 1 --Graff, Malebranche of the Burning Abyss
+99177923 1 --Infernity Archfiend
+68184115 1 --Inzektor Dragonfly
+69207766 1 --Inzektor Hornet
+07902349 1 --Left Arm of the Forbidden One
+44519536 1 --Left Leg of the Forbidden One
+92746535 1 --Luster Pendulum, the Dracoslayer
+41386308 1 --Mathematician
+28297833 1 --Necroface
+80344569 1 --Neo-Spacian Grand Mole
+16226786 1 --Night Assailant
+47075569 1 --Performapal Pendulum Sorcerer
+40318957 1 --Performapal Skullcrobat Joker
+65518099 1 --Qliphort Scout
+88264978 1 --Red-Eyes Darkness Metal Dragon
+85138716 1 --Rescue Rabbit
+70903634 1 --Right Arm of the Forbidden One
+08124921 1 --Right Leg of the Forbidden One
+84764038 1 --Scarm, Malebranche of the Burning Abyss
+91110378 1 --Star Seraph Sovereign
+00423585 1 --Summoner Monk
+71564252 1 --Thunder King Rai-Oh
+10802915 1 --Tour Guide From the Underworld
+59297550 1 --Wind-Up Magician
+72714461 1 --Wisdom-Eye Magician
+06602300 1 --Blaze Fenix, the Burning Bombardment Bird
+48063985 1 --Ritual Beast Ulti-Cannahawk
+63519819 1 --Thousand-Eyes Restrict
+45222299 1 --Evigishki Gustkraken
+11877465 1 --Evigishki Mind Augus
+26674724 1 --Nekroz of Brionac
+89463537 1 --Nekroz of Unicore
+70583986 1 --Dewloren, Tiger King of the Ice Barrier
+18239909 1 --Ignister Prominence, the Blasting Dracoslayer
+90953320 1 --T.G. Hyper Librarian
+52687916 1 --Trishula, Dragon of the Ice Barrier
+83531441 1 --Dante, Traveler of the Burning Abyss
+14087893 1 --Book of Moon
+48976825 1 --Burial From a Different Dimension
+53129443 1 --Dark Hole
+81674782 1 --Dimensional Fissure
+15854426 1 --Divine Wind of Mist Valley
+84171830 1 --Domain of the True Monarchs
+14733538 1 --Draco Face-Off
+62265044 1 --Dragon Ravine
+06417578 1 --El Shaddoll Fusion
+67723438 1 --Emergency Teleport
+95308449 1 --Final Countdown
+81439173 1 --Foolish Burial
+75500286 1 --Gold Sarcophagus
+66957584 1 --Infernity Launcher
+23171610 1 --Limiter Removal
+93600443 1 --Mask Change II
+37520316 1 --Mind Control
+43040603 1 --Monster Gate
+97211663 1 --Nekroz Cycle
+33782437 1 --One Day of Peace
+02295440 1 --One for One
+22842126 1 --Pantheism of the Monarchs
+53208660 1 --Pendulum Call
+96729612 1 --Preparation of Rites
+23701465 1 --Primal Seed
+58577036 1 --Reasoning
+32807846 1 --Reinforcement of the Army
+74845897 1 --Rekindling
+72405967 1 --Royal Tribute
+17639150 1 --Saqlifice
+45305419 1 --Symbol of Heritage
+70368879 1 --Upstart Goblin
+29401950 1 --Bottomless Trap Hole
+36468556 1 --Ceasefire
+94192409 1 --Compulsory Evacuation Device
+54974237 1 --Eradicator Epidemic Virus
+09059700 1 --Infernity Barrier
+30241314 1 --Macro Cosmos
+32723153 1 --Magical Explosion
+83555666 1 --Ring of Destruction
+82732705 1 --Skill Drain
+84749824 1 --Solemn Warning
+73599290 1 --Soul Drain
+53582587 1 --Torrential Tribute
+05851097 1 --Vanity's Emptiness
+#semi limit
+74311226 2 --Atlantean Dragoons
+85087012 2 --Card Trooper
+57143342 2 --Cir, Malebranche of the Burning Abyss
+14943837 2 --Debris Dragon
+37742478 2 --Honest
+92826944 2 --Mezuki
+10028593 2 --Reborn Tengu
+01475311 2 --Allure of Darkness
+91623717 2 --Chain Strike
+94886282 2 --Charge of the Light Brigade
+29843091 2 --Ojama Trio
+77505534 2 --Sinister Shadow Games
+
+!2016.4 Anime
+#forbidden anime
+511000822 0 --Crush Card Virus
+511002481 0 --Soul Exchange
+511002598 0 --Glow-Up Bulb
+511000736 0 --Wing Requital
+100000239 0 --Xyz Treasure
 100000000 0 --Chaos End Ruler -Ruler of the Beginning and the End-
-41181774  0 --Earthbound Immortal Wiraqocha Rasca
-10000000  0 --Obelisk the Tormentor
 511000787 0 --Rose Shaman
-10000010  0 --The Winged Dragon of Ra
-100000020 0 --After Glow
+511000814 0 --Extra Fusion
+511000672 0 --Fire Whip
+511001629 0 --Graveyard Rebound
+511000333 0 --Quick Rush
+511001582 0 --Performage Hurricane
+810000088 0 --Pillager
+511001307 0 --Energy Drain
+511000435 0 --Golden Castle of Stromberg
+511001417 0 --Water of Life
+511001125 0 --Life Shaver
+511000866 0 --Xyz Trasure Ticket
+95000000 0 --Boss Duel
+511001758 0 --Akashic Record
+511000729 0 --Berserk Mode
+511001186 0 --Contract with Don Thousand
+511001143 0 --Power Balance
+29654737 0 --Amazoness Chain Master
+110000110 0 --Big Bang Blow
+100000704 0 --Darkness Outsider
+511000585 0 --Level Jar
+511000618 0 --Insightful Cards of Reversal
 170000119 0 --Blasting Vein
 511000691 0 --Card Exchange
 511000207 0 --Card of Burial Magic
@@ -788,8 +730,6 @@
 42664989  0 --Card of Sanctity
 511000204 0 --Card of Spell Containment
 511000654 0 --Card of Variation
-800000002 0 --Chameleon Colors
-511000167 0 --Dark Wall of Wind
 810000021 0 --Deepest Impact
 511000471 0 --Drawber
 810000082 0 --Giant Flood
@@ -818,152 +758,153 @@
 511001119 0 --Deck Destruction Virus
 511000464 0 --Domain of the Dark Ruler
 800000000 0 --Forceful Deal
-61705417  0 --Graverobber
-511000618 0 --Insightful Cards of Reversal
-37520316  0 --Mind Control
-511000481 0 --Mirror of Duality
-511001143 0 --Power Balance
-511001505 0 --Rebirth Tablet
-511001499 0 --Take One Chance
-29654737 0 --Amazoness Chain Master
-19028307 0 --Beast Machine King Barbaros Ür
-110000110 0 --Big Bang Blow
-100000704 0 --Darkness Outsider
-100000700 0 --Darkness Seed
-511000585 0 --Level Jar
-31709826 0 --Revival Jam
-511000251 0 --Valkyrie of the Nordic Ascendant
-10000020 0 --Slifer the Sky Dragon
-511001515 0 --Sniping Hazy Type-0
-511001658 0 --Stardust Chronicle Spark Dragon
-98045062 0 --Enemy Controller
-81439173 0 --Foolish Burial
-51100561 0 --Get Your Game On!
-511000435 0 --Golden Castle of Stromberg
-511000970 0 --Mirror Prison
-511001453 0 --Misdirection Wing
-511001417 0 --Water of Life
-511001125 0 --Life Shaver
-511000866 0 --Xyz Trasure Ticket
-95000000 0 --Boss Duel
-511001758 0 --Akashic Record
-511000729 0 --Berserk Mode
-511001186 0 --Contract with Don Thousand
+37520316 0 --Mind Control
 57728570 0 --Crush Card Virus
-170000170 0 --Divine Serpent
-511001307 0 --Energy Drain
 17484499 0 --Exchange of the Spirit
-13893596 0 --Exodius the Ultimate Forbidden Lord
-511000814 0 --Extra Fusion
-511000672 0 --Fire Whip
-511001629 0 --Graveyard Rebound
-511001273 0 --Number 37: Hope Woven Dragon Spider Shark
-511000333 0 --Quick Rush
-511001582 0 --Performage Hurricane
-810000088 0 --Pillager
-83555666 0 --Ring of Destruction
 29762407 0 --Temple of the Kings
-511000736 0 --Wing Requital
+511000920 0 --Spell Transfer
 100000239 0 --Xyz Treasure
-#limit
-28985331 1 --Armageddon Knight
-85103922 1 --Artifact Moralltach
-72989439 1 --Black Luster Soldier - Envoy of the Beginning
-15341821 1 --Dandylion
-65192027 1 --Dark Armed Dragon
-14943837 1 --Debris Dragon
-78868119 1 --Deep Sea Diva
-50720316 1 --Elemental HERO Shadow Mist
-33396948 1 --Exodia the Forbidden One
-64034255 1 --Genex Ally Birdman
-67441435 1 --Glow-Up Bulb
-20758643 1 --Graff, Malebranche of the Burning Abyss
-99177923 1 --Infernity Archfiend
-72714461 1 --Insight Magician
-68184115 1 --Inzektor Dragonfly
-69207766 1 --Inzektor Hornet
-07902349 1 --Left Arm of the Forbidden One
-44519536 1 --Left Leg of the Forbidden One
-41386308 1 --Mathematician
-28297833 1 --Necroface
-80344569 1 --Neo-Spacian Grand Mole
-16226786 1 --Night Assailant
-65518099 1 --Qliphort Scout
-88264978 1 --Red-Eyes Darkness Metal Dragon
-85138716 1 --Rescue Rabbit
-70903634 1 --Right Arm of the Forbidden One
-08124921 1 --Right Leg of the Forbidden One
-91110378 1 --Star Seraph Sovereign
-00423585 1 --Summoner Monk
-71564252 1 --Thunder King Rai-Oh
-10802915 1 --Tour Guide From the Underworld
-59297550 1 --Wind-Up Magician
-06602300 1 --Blaze Fenix, the Burning Bombardment Bird
-48063985 1 --Ritual Beast Ulti-Cannahawk
-45222299 1 --Evigishki Gustkraken
-11877465 1 --Evigishki Mind Augus
-26674724 1 --Nekroz of Brionac
-89463537 1 --Nekroz of Unicore
-70583986 1 --Dewloren, Tiger King of the Ice Barrier
-90953320 1 --T.G. Hyper Librarian
-52687916 1 --Trishula, Dragon of the Ice Barrier
-01475311 1 --Allure of Darkness
-14087893 1 --Book of Moon
-48976825 1 --Burial From a Different Dimension
-53129443 1 --Dark Hole
-81674782 1 --Dimensional Fissure
-15854426 1 --Divine Wind of Mist Valley
-62265044 1 --Dragon Ravine
-06417578 1 --El Shaddoll Fusion
-95308449 1 --Final Countdown
-75500286 1 --Gold Sarcophagus
-66957584 1 --Infernity Launcher
-23171610 1 --Limiter Removal
-43040603 1 --Monster Gate
-97211663 1 --Nekroz Cycle
-33782437 1 --One Day of Peace
-02295440 1 --One for One
-96729612 1 --Preparation of Rites
-23701465 1 --Primal Seed
-32807846 1 --Reinforcement of the Army
-74845897 1 --Rekindling
-72405967 1 --Royal Tribute
-17639150 1 --Saqlifice
-45305419 1 --Symbol of Heritage
-29401950 1 --Bottomless Trap Hole
-36468556 1 --Ceasefire
-94192409 1 --Compulsory Evacuation Device
-54974237 1 --Eradicator Epidemic Virus
-09059700 1 --Infernity Barrier
-30241314 1 --Macro Cosmos
-32723153 1 --Magical Explosion
-83555666 1 --Ring of Destruction
-82732705 1 --Skill Drain
-84749824 1 --Solemn Warning
-73599290 1 --Soul Drain
-53582587 1 --Torrential Tribute
-05851097 1 --Vanity's Emptiness
-17078030 1 --Wall of Revealing Light
-511001131 1 --Clone Dragon
-511000585 1 --Level Jar
-67098114  1 --Loki, Lord of the Aesir
-100000008 1 --Michion, the Timelord
-93483212  1 --Odin, Father of the Aesir
-21208154  1 --The Wicked Avatar
-62180201  1 --The Wicked Dreadroot
-57793869  1 --The Wicked Eraser
-30604579  1 --Thor, Lord of the Aesir
-6007213   1 --Uria, Lord of Searing Flames
-810000032 1 --Depth Eruption
-511000598 1 --Fallout
-110000102 1 --Living Fossil
-511000276 1 --Numeron Direct
-500000149 1 --Soul-Binding Gate
-62499965  1 --Z-ONE
-110000099 1 --Cursed Prison
-100000565 1 --Freezing Dance
+100000312 0 --Past Life
+511001207 0 --Draw Slime
+100000274 0 --Destiny HERO - The Dark Angel
+100000474 0 --Fusion Birth
+511000407 0 --Curse Transfer
+810000032 0 --Depth Eruption
+10000020 0 --Slifer the Sky Dragon
+10000010 0 --The Winged Dragon of Ra
+10000000 0 --Obelisk the Tormentor
+450000130 0 --Card of Last Will
+512000007 0 --Underworld Circle
+512000008 0 --Nibelung's Treasure
+513000000 0 --Virus Cannon
+511002736 0 --Hell Gift
+513000027 0 --Ebon Sun
+513000007 0 --Sea of Rebirth
+513000009 0 --Crush Card Virus
+#forbidden tcg ocg
+27279764 0 --Apoqliphort Towers
+53804307 0 --Blaster, Dragon Ruler of Infernos
+82301904 0 --Chaos Emperor Dragon - Envoy of the End
+34124316 0 --Cyber Jar
+69015963 0 --Cyber-Stein
+56570271 0 --Destiny HERO - Disk Commander
+08903700 0 --Djinn Releaser of Rituals
+40044918 0 --Elemental HERO Stratos
+78706415 0 --Fiber Jar
+93369354 0 --Fishborg Blaster
+21593977 0 --Makyura the Destructor
+34206604 0 --Magical Scientist
+31560081 0 --Magician of Faith
+96782886 0 --Mind Master
+33508719 0 --Morphing Jar
+79106360 0 --Morphing Jar #2
+17330916 0 --Performapal Monkeyboard
+90411554 0 --Redox, Dragon Ruler of Boulders
+14878871 0 --Rescue Cat
+89399912 0 --Tempest, Dragon Ruler of Storms
+26400609 0 --Tidal, Dragon Ruler of Waterfalls
+33184167 0 --Tribe-Infecting Virus
+44910027 0 --Victory Dragon
+16923472 0 --Wind-Up Hunter
+78010363 0 --Witch of the Black Forest
+26202165 0 --Sangan
+90307777 0 --Shurit, Strategist of the Nekroz
+20663556 0 --Substitoad
+03078576 0 --Yata-Garasu
+20366274 0 --El Shaddoll Construct
+17412721 0 --Elder Entity Norden
+50321796 0 --Brionac, Dragon of the Ice Barrier
+07391448 0 --Goyo Guardian
+46772449 0 --Evilswarm Exciton Knight
+34086406 0 --Lavalval Chain
+54719828 0 --Number 16: Shock Master
+18326736 0 --Tellarknight Ptolemaeus
+81122844 0 --Wind-Up Carrier Zenmaity
+87910978 0 --Brain Control
+69243953 0 --Butterfly Dagger - Elma
+72892473 0 --Card Destruction
+57953380 0 --Card of Safe Return
+04031928 0 --Change of Heart
+67616300 0 --Chicken Game
+60682203 0 --Cold Wave
+17375316 0 --Confiscation
+44763025 0 --Delinquent Duo
+23557835 0 --Dimension Fusion
+77565204 0 --Future Fusion
+27970830 0 --Gateway of the Six
+42703248 0 --Giant Trunade
+79571449 0 --Graceful Charity
+18144506 0 --Harpie's Feather Duster
+19613556 0 --Heavy Storm
+85602018 0 --Last Will
+17178486 0 --Life Equalizer
+34906152 0 --Mass Driver
+46411259 0 --Metamorphosis
+41482598 0 --Mirage of Nightmare
+83764718 0 --Monster Reborn
+74191942 0 --Painful Choice
+67169062 0 --Pot of Avarice
+55144522 0 --Pot of Greed
+70828912 0 --Premature Burial
+12580477 0 --Raigeki
+45986603 0 --Snatch Steal
+46448938 0 --Spellbook of Judgment
+48130397 0 --Super Polymerization
+27770341 0 --Super Rejuvenation
+42829885 0 --The Forceful Sentry
+31222701 0 --Wavering Eyes
+61740673 0 --Imperial Order
+28566710 0 --Last Turn
+27174286 0 --Return from the Different Dimension
+93016201 0 --Royal Oppression
+57585212 0 --Self-Destruct Button
+03280747 0 --Sixth Sense
+41420027 0 --Solemn Judgment
+35316708 0 --Time Seal
+64697231 0 --Trap Dustshoot
+80604091 0 --Ultimate Offering
+513000002 0 --Mirror Wall
+513000057 0 --Sabatiel - The Philosopher's Stone
+#limit anime
+511000680 1 --Ice Age Panic
+511001614 1 --Spirit Xyz Spark
+511001642 1 --Synchro Alliance
+100000478 1 --Ties of the Brethren
+511000551 1 --Treasures of the Dead
+511001172 1 --Underwater Snow Prison
+511000829 1 --Re-Xyz
+100000470 1 --Soul Fusion
+511000809 1 --Spectral Ice Floe
+511001612 1 --Numbers Exist
+511001583 1 --Fortress of Prophecy
+501000081 1 --Sakyo, Swordsmaster of the Far East
+501000080 1 --Kuzunoha, the Onmyojin
+501000079 1 --The Twin Kings, Founders of the Empire
+501000078 1 --Leonardo's Silver Skyship
+501000019 1 --Grandopolis, the Eternal Golden City
+501000018 1 --E Hero Pit Boss
+501000017 1 --Legendary Magician of Dark
+501000016 1 --Legendary Magician of White
+501000015 1 --Queen Nereia the Silvercrown
+501000014 1 --King Landia the Goldfang
+501000013 1 --Grizzly, the Red Star Beast
+501000012 1 --Stardust Divinity
+501000011 1 --Skuna, the Leonine Rakan
+501000010 1 --Aggiba, the Malevolent Sh'nn S'yo
+501000009 1 --Lorelei, the Symphonic Arsenal
+501000008 1 --Tyr, the Vanquishing Warlord
+501000007 1 --Emperor of Lightning
+501000006 1 --Chimaera, the Master of Beasts
+501000005 1 --Armament of the Lethal Lords
+501000004 1 --Testament of the Arcane Lords
+501000003 1 --Queen of Fate - Eternia
+501000002 1 --King of Destruction - Xexex
+501000001 1 --Meteo the Matchless
+501000000 1 --Ulevo
+511000544 1 --Mother Spider
+511000789 1 --Briar Transplant
+511000800 1 --Celestial Bell Tower
 511000036 1 --Jurassic Impact
-100000117 1 --Life Force
 810000002 1 --Dark Spell Regeneration
 511000418 1 --Beckon to Darkness
 500000147 1 --École de Zone
@@ -1001,56 +942,140 @@
 95000041 1 --Infinite Light/Boss Duel
 95000042 1 --Sephylon, the Ultimate Timelord/Boss Duel
 511001726 1 --Ancient Gear Ultimate Hound Dog
-511000601 1 --Arcanatic Doomscythe
-81480460 1 --Barrel Dragon
-511000789 1 --Briar Transplant
-511000800 1 --Celestial Bell Tower
-511000992 1 --Circle of Terror
-511000407 1 --Curse Transfer
-32146097 1 --D/D Pandora
-100000274 1 --Destiny HERO - The Dark Angel
-511001207 1 --Draw Slime
-511001583 1 --Fortress of Prophecy
-100000474 1 --Fusion Birth
-511001627 1 --Galaxy Journey
-511000201 1 --Illusion Destruction
-511000988 1 --Masahiro the Dark Clown
-100000226 1 --Mirror Stage of Discipline
-511000544 1 --Mother Spider
-511001320 1 --Ninja Commando Kabuki
-06387204 1 --Number C6: Chronomaly Chaos Atlandis
-511001612 1 --Numbers Exist
-100000312 1 --Past Life
-110000104 1 --Psychic Armor Head
-45950291 1 --Rank-Up-Magic Astral Force
-511000829 1 --Re-Xyz
-100000470 1 --Soul Fusion
-511000809 1 --Spectral Ice Floe
-511001614 1 --Spirit Xyz Spark
-511001642 1 --Synchro Alliance
-511000920 1 --Spell Transfer
-100000478 1 --Ties of the Brethren
-511000551 1 --Treasures of the Dead
-511001172 1 --Underwater Snow Prison
-100000239 1 --Xyz Treasure
-810000022 1 --Zeta Reticulant
-#semi limit
+100000565 1 --Freezing Dance
+511000598 1 --Fallout
+110000102 1 --Living Fossil
+511000276 1 --Numeron Direct
+100000002 1 --Sandaion, the Timelord
+100000003 1 --Hailon, the Timelord
+100000004 1 --Raphion, the Timelord
+100000005 1 --Gabrion, the Timelord
+100000006 1 --Kamion, the Timelord
+100000007 1 --Zaphion, the Timelord
+100000008 1 --Michion, the Timelord
+100000009 1 --Lazion, the Timelord
+100000015 1 --Sadion, the Timelord
+511001131 1 --Clone Dragon
+511001273 1 --Number 37: Hope Woven Dragon Spider Shark
+170000170 1 --Divine Serpent
+51100561 1 --Get Your Game On!
+511000970 1 --Mirror Prison
+511000167 1 --Dark Wall of Wind
+81439173 1 --Foolish Burial
+511001821 1 --Necroid Synchro
+511001939 1 --Mimicat
+511001785 1 --Spell of Pain
+511002604 1 --Seal of Orichalcos
+200000002 1 --Creator of Miracles
+200000000 1 --Creator of Hope
+513000001 1 --Mirror Force
+513000031 1 --Shooting Quasar Dragon
+513000014 1 --T.G. Halberd Cannon
+#limit tcg ocg
+28985331 1 --Armageddon Knight
+85103922 1 --Artifact Moralltach
+72989439 1 --Black Luster Soldier - Envoy of the Beginning
+15341821 1 --Dandylion
+65192027 1 --Dark Armed Dragon
+78868119 1 --Deep Sea Diva
+50720316 1 --Elemental HERO Shadow Mist
+33396948 1 --Exodia the Forbidden One
+64034255 1 --Genex Ally Birdman
+20758643 1 --Graff, Malebranche of the Burning Abyss
+99177923 1 --Infernity Archfiend
+68184115 1 --Inzektor Dragonfly
+69207766 1 --Inzektor Hornet
+07902349 1 --Left Arm of the Forbidden One
+44519536 1 --Left Leg of the Forbidden One
+92746535 1 --Luster Pendulum, the Dracoslayer
+41386308 1 --Mathematician
+28297833 1 --Necroface
+80344569 1 --Neo-Spacian Grand Mole
+16226786 1 --Night Assailant
+47075569 1 --Performapal Pendulum Sorcerer
+40318957 1 --Performapal Skullcrobat Joker
+65518099 1 --Qliphort Scout
+88264978 1 --Red-Eyes Darkness Metal Dragon
+85138716 1 --Rescue Rabbit
+70903634 1 --Right Arm of the Forbidden One
+08124921 1 --Right Leg of the Forbidden One
+84764038 1 --Scarm, Malebranche of the Burning Abyss
+91110378 1 --Star Seraph Sovereign
+00423585 1 --Summoner Monk
+71564252 1 --Thunder King Rai-Oh
+10802915 1 --Tour Guide From the Underworld
+59297550 1 --Wind-Up Magician
+72714461 1 --Wisdom-Eye Magician
+06602300 1 --Blaze Fenix, the Burning Bombardment Bird
+48063985 1 --Ritual Beast Ulti-Cannahawk
+63519819 1 --Thousand-Eyes Restrict
+45222299 1 --Evigishki Gustkraken
+11877465 1 --Evigishki Mind Augus
+26674724 1 --Nekroz of Brionac
+89463537 1 --Nekroz of Unicore
+70583986 1 --Dewloren, Tiger King of the Ice Barrier
+18239909 1 --Ignister Prominence, the Blasting Dracoslayer
+90953320 1 --T.G. Hyper Librarian
+52687916 1 --Trishula, Dragon of the Ice Barrier
+83531441 1 --Dante, Traveler of the Burning Abyss
+14087893 1 --Book of Moon
+48976825 1 --Burial From a Different Dimension
+53129443 1 --Dark Hole
+81674782 1 --Dimensional Fissure
+15854426 1 --Divine Wind of Mist Valley
+84171830 1 --Domain of the True Monarchs
+14733538 1 --Draco Face-Off
+62265044 1 --Dragon Ravine
+06417578 1 --El Shaddoll Fusion
+67723438 1 --Emergency Teleport
+95308449 1 --Final Countdown
+81439173 1 --Foolish Burial
+75500286 1 --Gold Sarcophagus
+66957584 1 --Infernity Launcher
+23171610 1 --Limiter Removal
+93600443 1 --Mask Change II
+37520316 1 --Mind Control
+43040603 1 --Monster Gate
+97211663 1 --Nekroz Cycle
+33782437 1 --One Day of Peace
+02295440 1 --One for One
+22842126 1 --Pantheism of the Monarchs
+53208660 1 --Pendulum Call
+96729612 1 --Preparation of Rites
+23701465 1 --Primal Seed
+58577036 1 --Reasoning
+32807846 1 --Reinforcement of the Army
+74845897 1 --Rekindling
+72405967 1 --Royal Tribute
+17639150 1 --Saqlifice
+45305419 1 --Symbol of Heritage
+70368879 1 --Upstart Goblin
+29401950 1 --Bottomless Trap Hole
+36468556 1 --Ceasefire
+94192409 1 --Compulsory Evacuation Device
+54974237 1 --Eradicator Epidemic Virus
+09059700 1 --Infernity Barrier
+30241314 1 --Macro Cosmos
+32723153 1 --Magical Explosion
+83555666 1 --Ring of Destruction
+82732705 1 --Skill Drain
+84749824 1 --Solemn Warning
+73599290 1 --Soul Drain
+53582587 1 --Torrential Tribute
+05851097 1 --Vanity's Emptiness
+#semi limit anime
+511000494 2 --Effect Shut
+100000020 2 --After Glow
+#semi limit tcg ocg
 74311226 2 --Atlantean Dragoons
 85087012 2 --Card Trooper
 57143342 2 --Cir, Malebranche of the Burning Abyss
-09411399 2 --Destiny HERO - Malicious
+14943837 2 --Debris Dragon
 37742478 2 --Honest
-16404809 2 --Kuribandit
-22446869 2 --Mermail Abyssteus
 92826944 2 --Mezuki
 10028593 2 --Reborn Tengu
-98777036 2 --Tragoedia
-46052429 2 --Advanced Ritual Art
+01475311 2 --Allure of Darkness
 91623717 2 --Chain Strike
 94886282 2 --Charge of the Light Brigade
-41620959 2 --Dragon Shrine
 29843091 2 --Ojama Trio
 77505534 2 --Sinister Shadow Games
-511000494 2 --Effect Shut
-511001459 2 --Clear Effector
-511001821 2 --Necroid Synchro


### PR DESCRIPTION
This fixes the Traditional banlist based on 2016.4 TCG changes. There are no mistakes in 2016.4 TCG. It also updates the Anime banlist based on Ygopro forums. The Worlds banlist based on 2016.4 (TCG+OCG) has also been added. - AntiMetaman
