### PR TITLE
Update Anime banlist

### DIFF
--- a/lflist.conf
+++ b/lflist.conf
@@ -502,7 +502,7 @@
 01475311 2 --闇の誘惑
 14943837 2 --デブリ・ドラゴン
 
-!2016.4 Anime
+!2016.4 Worlds/Anime
 #forbidden anime
 511000822 0 --Crush Card Virus
 511002481 0 --Soul Exchange
@@ -676,6 +676,8 @@
 80604091 0 --Ultimate Offering
 513000002 0 --Mirror Wall
 513000057 0 --Sabatiel - The Philosopher's Stone
+68819554 0 --Performage Damage Juggler
+7563579 0 --Performage Plushfire
 #limit anime
 511000680 1 --Ice Age Panic
 511001614 1 --Spirit Xyz Spark
@@ -782,6 +784,8 @@
 513000001 1 --Mirror Force
 513000031 1 --Shooting Quasar Dragon
 513000014 1 --T.G. Halberd Cannon
+17078030 1 --Wall of Revealing Light
+95200000 1 --Command Duel
 #limit tcg ocg
 28985331 1 --Armageddon Knight
 85103922 1 --Artifact Moralltach


### PR DESCRIPTION
Updated Anime banlist to ban Performage Juggler, Performash Plushfire and limit Wall of Revealing Light as per OCG. Changed name from Anime to Worlds/Anime
