### PR TITLE
fix "When an opponent's monster declares an attack" conditions

### DIFF
--- a/script/c10759529.lua
+++ b/script/c10759529.lua
@@ -1,0 +1,36 @@
+--キッズ・ガード
+function c10759529.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c10759529.condition)
+	e1:SetCost(c10759529.cost)
+	e1:SetTarget(c10759529.target)
+	e1:SetOperation(c10759529.activate)
+	c:RegisterEffect(e1)
+end
+function c10759529.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c10759529.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.CheckReleaseGroup(tp,Card.IsCode,1,nil,32679370) end
+	local g=Duel.SelectReleaseGroup(tp,Card.IsCode,1,1,nil,32679370)
+	Duel.Release(g,REASON_COST)
+end
+function c10759529.filter(c)
+	return c:IsSetCard(0x3008) and c:IsType(TYPE_MONSTER) and c:IsAbleToHand()
+end
+function c10759529.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c10759529.filter,tp,LOCATION_DECK,0,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
+end
+function c10759529.activate(e,tp,eg,ep,ev,re,r,rp)
+	Duel.NegateAttack()
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local g=Duel.SelectMatchingCard(tp,c10759529.filter,tp,LOCATION_DECK,0,1,1,nil)
+	if g:GetCount()>0 then
+		Duel.SendtoHand(g,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,g)
+	end
+end

--- a/script/c12216615.lua
+++ b/script/c12216615.lua
@@ -1,0 +1,29 @@
+--コアキメイルの障壁
+function c12216615.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_DESTROY)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c12216615.condition)
+	e1:SetTarget(c12216615.target)
+	e1:SetOperation(c12216615.activate)
+	c:RegisterEffect(e1)
+end
+function c12216615.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp) and Duel.IsExistingMatchingCard(Card.IsCode,tp,LOCATION_GRAVE,0,2,nil,36623431)
+end
+function c12216615.filter(c)
+	return c:IsPosition(POS_FACEUP_ATTACK) and c:IsDestructable()
+end
+function c12216615.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c12216615.filter,tp,0,LOCATION_MZONE,1,nil) end
+	local g=Duel.GetMatchingGroup(c12216615.filter,tp,0,LOCATION_MZONE,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
+end
+function c12216615.activate(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetMatchingGroup(c12216615.filter,tp,0,LOCATION_MZONE,nil)
+	if g:GetCount()>0 then
+		Duel.Destroy(g,REASON_EFFECT)
+	end
+end

--- a/script/c1224927.lua
+++ b/script/c1224927.lua
@@ -1,0 +1,28 @@
+--邪神の大災害
+function c1224927.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_DESTROY)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c1224927.condition)
+	e1:SetTarget(c1224927.target)
+	e1:SetOperation(c1224927.activate)
+	c:RegisterEffect(e1)
+end
+function c1224927.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c1224927.filter(c)
+	return c:IsType(TYPE_SPELL+TYPE_TRAP) and c:IsDestructable()
+end
+function c1224927.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	if chk==0 then return Duel.IsExistingMatchingCard(c1224927.filter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,c) end
+	local sg=Duel.GetMatchingGroup(c1224927.filter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,c)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,sg,sg:GetCount(),0,0)
+end
+function c1224927.activate(e,tp,eg,ep,ev,re,r,rp)
+	local sg=Duel.GetMatchingGroup(c1224927.filter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,e:GetHandler())
+	Duel.Destroy(sg,REASON_EFFECT)
+end

--- a/script/c12255007.lua
+++ b/script/c12255007.lua
@@ -25,7 +25,7 @@ function c12255007.initial_effect(c)
 end
 
 function c12255007.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer()
+	return eg:GetFirst():IsControler(1-tp)
 end
 function c12255007.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckReleaseGroup(tp,Card.IsSetCard,1,nil,0x9f) end

--- a/script/c14315573.lua
+++ b/script/c14315573.lua
@@ -1,0 +1,27 @@
+--攻撃の無力化
+function c14315573.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c14315573.condition)
+	e1:SetTarget(c14315573.target)
+	e1:SetOperation(c14315573.activate)
+	c:RegisterEffect(e1)
+end
+function c14315573.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c14315573.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local tg=Duel.GetAttacker()
+	if chkc then return chkc==tg end
+	if chk==0 then return tg:IsOnField() and tg:IsCanBeEffectTarget(e) end
+	Duel.SetTargetCard(tg)
+end
+function c14315573.activate(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetAttacker()
+	if tc:IsRelateToEffect(e) and Duel.NegateAttack() then
+		Duel.SkipPhase(1-tp,PHASE_BATTLE,RESET_PHASE+PHASE_BATTLE,1)
+	end
+end

--- a/script/c14430063.lua
+++ b/script/c14430063.lua
@@ -1,0 +1,31 @@
+--インターセプト・デーモン
+function c14430063.initial_effect(c)
+	--damage
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(14430063,0))
+	e1:SetCategory(CATEGORY_DAMAGE)
+	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCondition(c14430063.damcon)
+	e1:SetTarget(c14430063.damtg)
+	e1:SetOperation(c14430063.damop)
+	c:RegisterEffect(e1)
+end
+function c14430063.damcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():IsPosition(POS_FACEUP_ATTACK) and Duel.GetAttacker():IsControler(1-tp)
+end
+function c14430063.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsRelateToEffect(e) end
+	Duel.SetTargetPlayer(1-tp)
+	Duel.SetTargetParam(500)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,500)
+end
+function c14430063.damop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsPosition(POS_FACEUP_ATTACK) and c:IsRelateToEffect(e) then
+		local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+		Duel.Damage(p,d,REASON_EFFECT)
+	end
+end

--- a/script/c16625614.lua
+++ b/script/c16625614.lua
@@ -147,7 +147,7 @@ function c16625614.dirtg(e,c)
 end
 
 function c16625614.atkcon(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer()
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c16625614.atktg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end

--- a/script/c18964575.lua
+++ b/script/c18964575.lua
@@ -1,0 +1,26 @@
+--速攻のかかし
+function c18964575.initial_effect(c)
+	--end battle phase
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(18964575,0))
+	e1:SetType(EFFECT_TYPE_QUICK_O)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetRange(LOCATION_HAND)
+	e1:SetCondition(c18964575.condition)
+	e1:SetCost(c18964575.cost)
+	e1:SetOperation(c18964575.operation)
+	c:RegisterEffect(e1)
+end
+function c18964575.condition(e,tp,eg,ep,ev,re,r,rp)
+	local at=Duel.GetAttacker()
+	return at:GetControler()~=tp and Duel.GetAttackTarget()==nil
+end
+function c18964575.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsDiscardable() end
+	Duel.SendtoGrave(e:GetHandler(),REASON_COST+REASON_DISCARD)
+end
+function c18964575.operation(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.NegateAttack() then
+		Duel.SkipPhase(1-tp,PHASE_BATTLE,RESET_PHASE+PHASE_BATTLE,1)
+	end
+end

--- a/script/c20522190.lua
+++ b/script/c20522190.lua
@@ -1,0 +1,29 @@
+--邪悪なるバリア －ダーク・フォース－
+function c20522190.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_REMOVE)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c20522190.condition)
+	e1:SetTarget(c20522190.target)
+	e1:SetOperation(c20522190.activate)
+	c:RegisterEffect(e1)
+end
+function c20522190.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c20522190.filter(c)
+	return c:IsDefencePos() and c:IsAbleToRemove()
+end
+function c20522190.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c20522190.filter,tp,0,LOCATION_MZONE,1,nil) end
+	local g=Duel.GetMatchingGroup(c20522190.filter,tp,0,LOCATION_MZONE,nil)
+	Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,g:GetCount(),0,0)
+end
+function c20522190.activate(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetMatchingGroup(c20522190.filter,tp,0,LOCATION_MZONE,nil)
+	if g:GetCount()>0 then
+		Duel.Remove(g,POS_FACEUP,REASON_EFFECT)
+	end
+end

--- a/script/c21481146.lua
+++ b/script/c21481146.lua
@@ -1,0 +1,29 @@
+--閃光のバリア－シャイニング・フォース－
+function c21481146.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_DESTROY)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c21481146.condition)
+	e1:SetTarget(c21481146.target)
+	e1:SetOperation(c21481146.activate)
+	c:RegisterEffect(e1)
+end
+function c21481146.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp) and Duel.IsExistingMatchingCard(Card.IsPosition,tp,0,LOCATION_MZONE,3,nil,POS_FACEUP_ATTACK)
+end
+function c21481146.filter(c)
+	return c:IsAttackPos() and c:IsDestructable()
+end
+function c21481146.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c21481146.filter,tp,0,LOCATION_MZONE,1,nil) end
+	local g=Duel.GetMatchingGroup(c21481146.filter,tp,0,LOCATION_MZONE,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
+end
+function c21481146.activate(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetMatchingGroup(c21481146.filter,tp,0,LOCATION_MZONE,nil)
+	if g:GetCount()>0 then
+		Duel.Destroy(g,REASON_EFFECT)
+	end
+end

--- a/script/c21558682.lua
+++ b/script/c21558682.lua
@@ -1,0 +1,62 @@
+--ディフェンド・スライム
+function c21558682.initial_effect(c)
+	--activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(0,TIMING_BATTLE_START)
+	e1:SetTarget(c21558682.atktg1)
+	e1:SetOperation(c21558682.atkop)
+	c:RegisterEffect(e1)
+	--change target
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(21558682,0))
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetCondition(c21558682.atkcon)
+	e2:SetTarget(c21558682.atktg2)
+	e2:SetOperation(c21558682.atkop)
+	c:RegisterEffect(e2)
+end
+function c21558682.atkcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp) and Duel.GetAttackTarget()~=nil
+end
+function c21558682.filter(c,atg)
+	return c:IsFaceup() and c:IsCode(31709826) and atg:IsContains(c)
+end
+function c21558682.atktg1(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then
+		local atg=Duel.GetAttacker():GetAttackableTarget()
+		local at=Duel.GetAttackTarget()
+		return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and chkc~=at and c21558682.filter(chkc,atg)
+	end
+	if chk==0 then return true end
+	e:SetProperty(0)
+	if Duel.CheckEvent(EVENT_ATTACK_ANNOUNCE) and Duel.GetAttacker():IsControler(1-tp) then
+		local at=Duel.GetAttackTarget()
+		local atg=Duel.GetAttacker():GetAttackableTarget()
+		if at and Duel.IsExistingTarget(c21558682.filter,tp,LOCATION_MZONE,0,1,at,atg)
+			and Duel.SelectYesNo(tp,94) then
+			e:SetProperty(EFFECT_FLAG_CARD_TARGET)
+			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
+			Duel.SelectTarget(tp,c21558682.filter,tp,LOCATION_MZONE,0,1,1,at,atg)
+		end
+	end
+end
+function c21558682.atktg2(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local atg=Duel.GetAttacker():GetAttackableTarget()
+	local at=Duel.GetAttackTarget()
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and chkc~=at and c21558682.filter(chkc,atg) end
+	if chk==0 then return Duel.IsExistingTarget(c21558682.filter,tp,LOCATION_MZONE,0,1,at,atg) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
+	Duel.SelectTarget(tp,c21558682.filter,tp,LOCATION_MZONE,0,1,1,at,atg)
+end
+function c21558682.atkop(e,tp,eg,ep,ev,re,r,rp)
+	if not e:GetHandler():IsRelateToEffect(e) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsFaceup() and tc:IsRelateToEffect(e) and not Duel.GetAttacker():IsImmuneToEffect(e) then
+		Duel.ChangeAttackTarget(tc)
+	end
+end

--- a/script/c21597117.lua
+++ b/script/c21597117.lua
@@ -1,0 +1,36 @@
+--ヒーロー見参
+function c21597117.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c21597117.condition)
+	e1:SetTarget(c21597117.target)
+	e1:SetOperation(c21597117.activate)
+	c:RegisterEffect(e1)
+end
+function c21597117.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c21597117.spfilter(c,e,tp)
+	return c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c21597117.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingMatchingCard(c21597117.spfilter,tp,LOCATION_HAND,0,1,nil,e,tp) end
+end
+function c21597117.activate(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 or not Duel.IsPlayerCanSpecialSummon(tp) then return end
+	local g=Duel.GetFieldGroup(tp,LOCATION_HAND,0)
+	local sg=g:RandomSelect(1-tp,1)
+	local tc=sg:GetFirst()
+	if tc then
+		Duel.ConfirmCards(1-tp,tc)
+		if tc:IsCanBeSpecialSummoned(e,0,tp,false,false) then
+			Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)
+		else
+			Duel.SendtoGrave(tc,REASON_EFFECT)
+		end
+	end
+end

--- a/script/c21598948.lua
+++ b/script/c21598948.lua
@@ -1,0 +1,76 @@
+--モンスターBOX
+function c21598948.initial_effect(c)
+	--activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(0,TIMING_MAIN_END)
+	e1:SetTarget(c21598948.atktg1)
+	e1:SetOperation(c21598948.atkop)
+	c:RegisterEffect(e1)
+	--atk change
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(21598948,0))
+	e2:SetCategory(CATEGORY_ATKCHANGE+CATEGORY_COIN)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e2:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetCondition(c21598948.atkcon)
+	e2:SetTarget(c21598948.atktg2)
+	e2:SetOperation(c21598948.atkop)
+	c:RegisterEffect(e2)
+	--maintain
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e3:SetCode(EVENT_PHASE+PHASE_STANDBY)
+	e3:SetRange(LOCATION_SZONE)
+	e3:SetCountLimit(1)
+	e3:SetCondition(c21598948.mtcon)
+	e3:SetOperation(c21598948.mtop)
+	c:RegisterEffect(e3)
+end
+function c21598948.atkcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c21598948.atktg1(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	e:SetLabel(0)
+	if Duel.CheckEvent(EVENT_ATTACK_ANNOUNCE) and Duel.GetAttacker():IsControler(1-tp) then
+		e:SetLabel(1)
+		Duel.SetTargetCard(Duel.GetAttacker())
+		Duel.SetOperationInfo(0,CATEGORY_COIN,nil,0,tp,1)
+	end
+end
+function c21598948.atktg2(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	e:SetLabel(1)
+	Duel.SetTargetCard(Duel.GetAttacker())
+	Duel.SetOperationInfo(0,CATEGORY_COIN,nil,0,tp,1)
+end
+function c21598948.atkop(e,tp,eg,ep,ev,re,r,rp)
+	if e:GetLabel()==0 or not e:GetHandler():IsRelateToEffect(e) then return end
+	local a=Duel.GetAttacker()
+	if not a:IsRelateToEffect(e) then return end
+	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(21598948,4))
+	local coin=Duel.SelectOption(tp,aux.Stringid(21598948,2),aux.Stringid(21598948,3))
+	local res=Duel.TossCoin(tp,1)
+	if coin~=res then
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_SET_ATTACK_FINAL)
+		e1:SetValue(0)
+		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_BATTLE)
+		a:RegisterEffect(e1)
+	end
+end
+function c21598948.mtcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetTurnPlayer()==tp
+end
+function c21598948.mtop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.CheckLPCost(tp,500) and Duel.SelectYesNo(tp,aux.Stringid(21598948,1)) then
+		Duel.PayLPCost(tp,500)
+	else
+		Duel.Destroy(e:GetHandler(),REASON_COST)
+	end
+end

--- a/script/c22047978.lua
+++ b/script/c22047978.lua
@@ -1,0 +1,51 @@
+--バトル・ブレイク
+function c22047978.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_DESTROY)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c22047978.condition)
+	e1:SetTarget(c22047978.target)
+	e1:SetOperation(c22047978.activate)
+	c:RegisterEffect(e1)
+end
+function c22047978.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c22047978.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	local tg=Duel.GetAttacker()
+	if chk==0 then return tg:IsOnField() end
+	Duel.SetTargetCard(tg)
+	if Duel.GetFieldGroupCount(tp,0,LOCATION_HAND)==0 then
+		Duel.SetOperationInfo(0,CATEGORY_DESTROY,tg,1,0,0)
+	end
+end
+function c22047978.cfilter(c)
+	return not c:IsPublic() and c:IsType(TYPE_MONSTER)
+end
+function c22047978.activate(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.IsChainDisablable(0) then
+		local sel=1
+		local g=Duel.GetMatchingGroup(c22047978.cfilter,1-tp,LOCATION_HAND,0,nil)
+		Duel.Hint(HINT_SELECTMSG,1-tp,aux.Stringid(22047978,0))
+		if g:GetCount()>0 then
+			sel=Duel.SelectOption(1-tp,1213,1214)
+		else
+			sel=Duel.SelectOption(1-tp,1214)+1
+		end
+		if sel==0 then
+			Duel.Hint(HINT_SELECTMSG,1-tp,HINTMSG_CONFIRM)
+			local cg=g:Select(1-tp,1,1,nil)
+			Duel.ConfirmCards(tp,cg)
+			Duel.ShuffleHand(1-tp)
+			Duel.NegateEffect(0)
+			return
+		end
+	end
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) and tc:IsAttackable() and not tc:IsStatus(STATUS_ATTACK_CANCELED)
+		and Duel.Destroy(tc,REASON_EFFECT)>0 then
+		Duel.SkipPhase(1-tp,PHASE_BATTLE,RESET_PHASE+PHASE_BATTLE,1)
+	end
+end

--- a/script/c22991179.lua
+++ b/script/c22991179.lua
@@ -1,0 +1,41 @@
+--無視加護
+function c22991179.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	c:RegisterEffect(e1)
+	--negate attack
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(22991179,0))
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e2:SetCondition(c22991179.condition)
+	e2:SetCost(c22991179.cost)
+	e2:SetTarget(c22991179.target)
+	e2:SetOperation(c22991179.activate)
+	c:RegisterEffect(e2)
+end
+function c22991179.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c22991179.cfilter(c)
+	return c:IsRace(RACE_INSECT) and c:IsAbleToRemoveAsCost()
+end
+function c22991179.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c22991179.cfilter,tp,LOCATION_GRAVE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+	local g=Duel.SelectMatchingCard(tp,c22991179.cfilter,tp,LOCATION_GRAVE,0,1,1,nil)
+	Duel.Remove(g,POS_FACEUP,REASON_COST)
+end
+function c22991179.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local tg=Duel.GetAttacker()
+	if chkc then return chkc==tg end
+	if chk==0 then return tg:IsOnField() and tg:IsCanBeEffectTarget(e) end
+	Duel.SetTargetCard(tg)
+end
+function c22991179.activate(e,tp,eg,ep,ev,re,r,rp)
+	Duel.NegateAttack()
+end

--- a/script/c24673894.lua
+++ b/script/c24673894.lua
@@ -1,0 +1,35 @@
+--チェンジ・デステニー
+function c24673894.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c24673894.condition)
+	e1:SetTarget(c24673894.target)
+	e1:SetOperation(c24673894.activate)
+	c:RegisterEffect(e1)
+end
+function c24673894.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c24673894.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local tg=Duel.GetAttacker()
+	if chkc then return chkc==tg end
+	if chk==0 then return tg:IsOnField() and tg:IsCanBeEffectTarget(e) end
+	Duel.SetTargetCard(tg)
+end
+function c24673894.activate(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetAttacker()
+	if tc:IsRelateToEffect(e) and Duel.NegateAttack() and Duel.ChangePosition(tc,POS_FACEUP_DEFENCE)~=0 then
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_CANNOT_CHANGE_POSITION)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		tc:RegisterEffect(e1)
+		local val=tc:GetAttack()/2
+		local op=Duel.SelectOption(1-tp,aux.Stringid(24673894,0),aux.Stringid(24673894,1))
+		if op==0 then Duel.Recover(1-tp,val,REASON_EFFECT)
+		else Duel.Damage(tp,val,REASON_EFFECT) end
+	end
+end

--- a/script/c25642998.lua
+++ b/script/c25642998.lua
@@ -1,0 +1,38 @@
+--ポセイドン・ウェーブ
+function c25642998.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_DAMAGE)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c25642998.condition)
+	e1:SetTarget(c25642998.target)
+	e1:SetOperation(c25642998.activate)
+	c:RegisterEffect(e1)
+end
+function c25642998.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c25642998.dfilter(c)
+	return c:IsFaceup() and c:IsRace(RACE_FISH+RACE_SEASERPENT+RACE_AQUA)
+end
+function c25642998.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local tg=Duel.GetAttacker()
+	if chkc then return chkc==tg end
+	if chk==0 then return tg:IsOnField() and tg:IsCanBeEffectTarget(e) end
+	Duel.SetTargetCard(tg)
+	local dam=Duel.GetMatchingGroupCount(c25642998.dfilter,tp,LOCATION_MZONE,0,nil)*800
+	if dam>0 then
+		Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,dam)
+	end
+end
+function c25642998.activate(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) and Duel.NegateAttack() then
+		local dam=Duel.GetMatchingGroupCount(c25642998.dfilter,tp,LOCATION_MZONE,0,nil)*800
+		if dam>0 then
+			Duel.Damage(1-tp,dam,REASON_EFFECT)
+		end
+	end
+end

--- a/script/c26533075.lua
+++ b/script/c26533075.lua
@@ -1,0 +1,58 @@
+--セキュリティー・ボール
+function c26533075.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_POSITION)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c26533075.condition)
+	e1:SetTarget(c26533075.target)
+	e1:SetOperation(c26533075.activate)
+	c:RegisterEffect(e1)
+	--Destroy
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(26533075,0))
+	e2:SetCategory(CATEGORY_DESTROY)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e2:SetCode(EVENT_TO_GRAVE)
+	e2:SetCondition(c26533075.descon)
+	e2:SetTarget(c26533075.destg)
+	e2:SetOperation(c26533075.desop)
+	c:RegisterEffect(e2)
+end
+function c26533075.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c26533075.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local tg=Duel.GetAttacker()
+	if chkc then return chkc==tg end
+	if chk==0 then return tg:IsOnField() and tg:IsCanBeEffectTarget(e) end
+	Duel.SetTargetCard(tg)
+	Duel.SetOperationInfo(0,CATEGORY_POSITION,tg,1,0,0)
+end
+function c26533075.activate(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) and tc:IsAttackable() and not tc:IsStatus(STATUS_ATTACK_CANCELED) then
+		Duel.ChangePosition(tc,POS_FACEUP_DEFENCE)
+	end
+end
+function c26533075.descon(e,tp,eg,ep,ev,re,r,rp)
+	return bit.band(r,REASON_DESTROY)~=0 and rp~=tp and re:IsActiveType(TYPE_SPELL+TYPE_TRAP)
+		and e:GetHandler():IsPreviousLocation(LOCATION_ONFIELD)
+		and e:GetHandler():IsPreviousPosition(POS_FACEDOWN)
+end
+function c26533075.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) end
+	if chk==0 then return Duel.IsExistingTarget(aux.TRUE,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local g=Duel.SelectTarget(tp,aux.TRUE,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
+end
+function c26533075.desop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) then
+		Duel.Destroy(tc,REASON_EFFECT)
+	end
+end

--- a/script/c36378044.lua
+++ b/script/c36378044.lua
@@ -1,0 +1,64 @@
+--ラッキーパンチ
+function c36378044.initial_effect(c)
+	--activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetTarget(c36378044.atktg1)
+	e1:SetOperation(c36378044.atkop)
+	c:RegisterEffect(e1)
+	--coin
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(36378044,0))
+	e2:SetCategory(CATEGORY_DRAW+CATEGORY_DESTROY+CATEGORY_COIN)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetLabel(1)
+	e2:SetCondition(c36378044.atkcon)
+	e2:SetTarget(c36378044.atktg2)
+	e2:SetOperation(c36378044.atkop)
+	c:RegisterEffect(e2)
+	--life lost
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e3:SetCode(EVENT_DESTROYED)
+	e3:SetCondition(c36378044.descon)
+	e3:SetOperation(c36378044.desop)
+	c:RegisterEffect(e3)
+end
+function c36378044.atkcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c36378044.atktg1(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	e:SetLabel(0)
+	if Duel.CheckEvent(EVENT_ATTACK_ANNOUNCE) and Duel.GetAttacker():IsControler(1-tp)
+		and Duel.SelectYesNo(tp,aux.Stringid(36378044,1)) then
+		e:SetLabel(1)
+		Duel.SetOperationInfo(0,CATEGORY_COIN,nil,0,tp,3)
+		e:GetHandler():RegisterFlagEffect(36378044,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
+	else e:SetLabel(0) end
+end
+function c36378044.atktg2(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():GetFlagEffect(36378044)==0 end
+	Duel.SetOperationInfo(0,CATEGORY_COIN,nil,0,tp,3)
+	e:GetHandler():RegisterFlagEffect(36378044,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
+end
+function c36378044.atkop(e,tp,eg,ep,ev,re,r,rp)
+	if e:GetLabel()==0 or not e:GetHandler():IsRelateToEffect(e) then return end
+	local r1,r2,r3=Duel.TossCoin(tp,3)
+	if r1+r2+r3==3 then
+		Duel.Draw(tp,3,REASON_EFFECT)
+	elseif r1+r2+r3==0 then
+		Duel.Destroy(e:GetHandler(),REASON_EFFECT)
+	end
+end
+function c36378044.descon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	return c:IsPreviousLocation(LOCATION_ONFIELD) and c:IsPreviousPosition(POS_FACEUP)
+end
+function c36378044.desop(e,tp,eg,ep,ev,re,r,rp)
+	local lp=Duel.GetLP(tp)
+	Duel.SetLP(tp,lp-6000)
+end

--- a/script/c36708764.lua
+++ b/script/c36708764.lua
@@ -1,0 +1,67 @@
+--ルーレット・スパイダー
+function c36708764.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_DICE+CATEGORY_DAMAGE+CATEGORY_DESTROY)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c36708764.condition)
+	e1:SetTarget(c36708764.target)
+	e1:SetOperation(c36708764.activate)
+	c:RegisterEffect(e1)
+end
+function c36708764.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c36708764.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	local at=Duel.GetAttacker()
+	Duel.SetTargetCard(at)
+	Duel.SetOperationInfo(0,CATEGORY_DICE,nil,0,tp,1)
+end
+function c36708764.activate(e,tp,eg,ep,ev,re,r,rp)
+	local dc=Duel.TossDice(tp,1)
+	if dc==1 then
+		local lp=Duel.GetLP(tp)
+		Duel.SetLP(tp,math.ceil(lp/2))
+		return
+	elseif dc==2 then
+		Duel.ChangeAttackTarget(nil)
+		return
+	elseif dc==3 then
+		local bc=Duel.GetAttackTarget()
+		local g=Duel.GetMatchingGroup(nil,tp,LOCATION_MZONE,0,bc)
+		if g:GetCount()>0 then
+			Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(36708764,0))
+			local tc=g:Select(tp,1,1,nil):GetFirst()
+			local at=Duel.GetAttacker()
+			if at:IsAttackable() and not at:IsImmuneToEffect(e) and not tc:IsImmuneToEffect(e) then
+				Duel.CalculateDamage(at,tc)
+			end
+		end
+		return
+	elseif dc==4 then
+		local at=Duel.GetAttacker()
+		local g=Duel.GetMatchingGroup(nil,tp,0,LOCATION_MZONE,at)
+		if g:GetCount()>0 then
+			Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(36708764,0))
+			local tc=g:Select(tp,1,1,nil):GetFirst()
+			local at=Duel.GetAttacker()
+			if at:IsAttackable() and not at:IsImmuneToEffect(e) and not tc:IsImmuneToEffect(e) then
+				Duel.CalculateDamage(at,tc)
+			end
+		end
+		return
+	elseif dc==5 then
+		local at=Duel.GetFirstTarget()
+		if at:IsRelateToEffect(e) and Duel.NegateAttack() and at:GetAttack()>0 then
+			Duel.Damage(1-tp,at:GetAttack(),REASON_EFFECT)
+		end
+		return
+	else
+		local at=Duel.GetFirstTarget()
+		if at:IsRelateToEffect(e) and at:IsControler(1-tp) and at:IsType(TYPE_MONSTER) then
+			Duel.Destroy(at,REASON_EFFECT)
+		end
+	end
+end

--- a/script/c37390589.lua
+++ b/script/c37390589.lua
@@ -1,0 +1,83 @@
+--鎖付きブーメラン
+function c37390589.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(TIMING_DAMAGE_STEP)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP)
+	e1:SetCondition(c37390589.condition)
+	e1:SetTarget(c37390589.target)
+	e1:SetOperation(c37390589.operation)
+	c:RegisterEffect(e1)
+end
+function c37390589.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetCurrentPhase()~=PHASE_DAMAGE or not Duel.IsDamageCalculated()
+end
+function c37390589.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then
+		if e:GetLabel()==0 then
+			return false
+		elseif e:GetLabel()==1 then
+			return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup()
+		else return false end
+	end
+	local b1=Duel.CheckEvent(EVENT_ATTACK_ANNOUNCE) and Duel.GetAttacker():IsControler(1-tp)
+		and Duel.GetAttacker():IsLocation(LOCATION_MZONE) and Duel.GetAttacker():IsCanBeEffectTarget(e)
+	local b2=Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,0,1,nil)
+	if chk==0 then return b1 or b2 end
+	local opt=0
+	if b1 and b2 then
+		opt=Duel.SelectOption(tp,aux.Stringid(37390589,0),aux.Stringid(37390589,1),aux.Stringid(37390589,2))
+	elseif b1 then
+		opt=Duel.SelectOption(tp,aux.Stringid(37390589,0))
+	else
+		opt=Duel.SelectOption(tp,aux.Stringid(37390589,1))+1
+	end
+	e:SetLabel(opt)
+	if opt==0 or opt==2 then
+		Duel.SetTargetCard(Duel.GetAttacker())
+	end
+	if opt==1 or opt==2 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+		local g=Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_MZONE,0,1,1,nil)
+		e:SetLabelObject(g:GetFirst())
+		Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+	end
+end
+function c37390589.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local opt=e:GetLabel()
+	if opt==0 or opt==2 then
+		local tc=Duel.GetAttacker()
+		if tc:IsRelateToEffect(e) and tc:IsFaceup() and tc:IsAttackable() and not tc:IsStatus(STATUS_ATTACK_CANCELED) then
+			Duel.ChangePosition(tc,POS_FACEUP_DEFENCE)
+		end
+	end
+	if opt==1 or opt==2 then
+		local tc=e:GetLabelObject()
+		if c:IsRelateToEffect(e) and tc:IsRelateToEffect(e) and tc:IsFaceup() then
+			Duel.Equip(tp,c,tc)
+			c:CancelToGrave()
+			--Atkup
+			local e1=Effect.CreateEffect(c)
+			e1:SetType(EFFECT_TYPE_EQUIP)
+			e1:SetCode(EFFECT_UPDATE_ATTACK)
+			e1:SetValue(500)
+			e1:SetReset(RESET_EVENT+0x1fe0000)
+			c:RegisterEffect(e1)
+			--Equip limit
+			local e2=Effect.CreateEffect(c)
+			e2:SetType(EFFECT_TYPE_SINGLE)
+			e2:SetCode(EFFECT_EQUIP_LIMIT)
+			e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+			e2:SetValue(c37390589.eqlimit)
+			e2:SetReset(RESET_EVENT+0x1fe0000)
+			c:RegisterEffect(e2)
+		end
+	end
+end
+function c37390589.eqlimit(e,c)
+	return c:GetControler()==e:GetOwnerPlayer()
+end

--- a/script/c37507488.lua
+++ b/script/c37507488.lua
@@ -1,0 +1,41 @@
+--モンスターレリーフ
+function c37507488.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_TOHAND+CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c37507488.condition)
+	e1:SetTarget(c37507488.target)
+	e1:SetOperation(c37507488.activate)
+	c:RegisterEffect(e1)
+end
+function c37507488.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c37507488.filter(c)
+	return c:IsAbleToHand()
+end
+function c37507488.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c37507488.filter(chkc) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>-1
+		and Duel.IsExistingTarget(c37507488.filter,tp,LOCATION_MZONE,0,1,nil)
+		and Duel.IsExistingMatchingCard(c37507488.spfilter,tp,LOCATION_HAND,0,1,nil,e,tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RTOHAND)
+	local g=Duel.SelectTarget(tp,c37507488.filter,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,1,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND)
+end
+function c37507488.spfilter(c,e,tp)
+	return c:GetLevel()==4 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c37507488.activate(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and Duel.SendtoHand(tc,nil,REASON_EFFECT)>0
+		and tc:IsLocation(LOCATION_HAND) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local g=Duel.SelectMatchingCard(tp,c37507488.spfilter,tp,LOCATION_HAND,0,1,1,nil,e,tp)
+		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
+	end
+end

--- a/script/c39537362.lua
+++ b/script/c39537362.lua
@@ -1,0 +1,51 @@
+--旅人の試練
+function c39537362.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetTarget(c39537362.target1)
+	e1:SetOperation(c39537362.activate)
+	c:RegisterEffect(e1)
+	--tohand
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(39537362,0))
+	e2:SetCategory(CATEGORY_TOHAND)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetLabel(1)
+	e2:SetCondition(c39537362.condition)
+	e2:SetTarget(c39537362.target2)
+	e2:SetOperation(c39537362.activate)
+	c:RegisterEffect(e2)
+end
+function c39537362.target1(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	if Duel.CheckEvent(EVENT_ATTACK_ANNOUNCE) and Duel.GetAttacker():IsControler(1-tp)
+		and Duel.SelectYesNo(tp,aux.Stringid(39537362,1)) then 
+		e:SetLabel(1)
+		Duel.SetTargetCard(Duel.GetAttacker())
+		e:GetHandler():RegisterFlagEffect(0,RESET_CHAIN,EFFECT_FLAG_CLIENT_HINT,1,0,aux.Stringid(39537362,2))
+	else e:SetLabel(0) end
+end
+function c39537362.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c39537362.target2(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return not e:GetHandler():IsStatus(STATUS_CHAINING) end
+	Duel.SetTargetCard(Duel.GetAttacker())
+end
+function c39537362.activate(e,tp,eg,ep,ev,re,r,rp)
+	if e:GetLabel()~=1 or Duel.GetFieldGroupCount(tp,LOCATION_HAND,0)==0
+		or not e:GetHandler():IsRelateToEffect(e) or not Duel.GetAttacker():IsRelateToEffect(e)	then return end
+	local g=Duel.GetFieldGroup(tp,LOCATION_HAND,0):RandomSelect(1-tp,1,nil)
+	local tc=g:GetFirst()
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_CARDTYPE)
+	local op=Duel.SelectOption(1-tp,70,71,72)
+	Duel.ConfirmCards(1-tp,tc)
+	Duel.ShuffleHand(tp)
+	if (op~=0 and tc:IsType(TYPE_MONSTER)) or (op~=1 and tc:IsType(TYPE_SPELL)) or (op~=2 and tc:IsType(TYPE_TRAP)) then
+		Duel.SendtoHand(Duel.GetAttacker(),nil,REASON_EFFECT)
+	end
+end

--- a/script/c40838625.lua
+++ b/script/c40838625.lua
@@ -1,0 +1,38 @@
+--砂塵のバリア －ダスト・フォース－
+function c40838625.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_POSITION)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c40838625.condition)
+	e1:SetTarget(c40838625.target)
+	e1:SetOperation(c40838625.activate)
+	c:RegisterEffect(e1)
+end
+function c40838625.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c40838625.filter(c)
+	return c:IsAttackPos() and c:IsCanTurnSet()
+end
+function c40838625.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c40838625.filter,tp,0,LOCATION_MZONE,1,nil) end
+	local g=Duel.GetMatchingGroup(c40838625.filter,tp,0,LOCATION_MZONE,nil)
+	Duel.SetOperationInfo(0,CATEGORY_POSITION,g,g:GetCount(),0,0)
+end
+function c40838625.activate(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetMatchingGroup(c40838625.filter,tp,0,LOCATION_MZONE,nil)
+	if Duel.ChangePosition(g,POS_FACEDOWN_DEFENCE)~=0 then
+		local og=Duel.GetOperatedGroup()
+		local tc=og:GetFirst()
+		while tc do
+			local e1=Effect.CreateEffect(e:GetHandler())
+			e1:SetType(EFFECT_TYPE_SINGLE)
+			e1:SetCode(EFFECT_CANNOT_CHANGE_POSITION)
+			e1:SetReset(RESET_EVENT+0x1fe0000)
+			tc:RegisterEffect(e1)
+			tc=og:GetNext()
+		end
+	end
+end

--- a/script/c43250041.lua
+++ b/script/c43250041.lua
@@ -1,0 +1,32 @@
+--ドレインシールド
+function c43250041.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_RECOVER)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c43250041.condition)
+	e1:SetTarget(c43250041.target)
+	e1:SetOperation(c43250041.activate)
+	c:RegisterEffect(e1)
+end
+function c43250041.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c43250041.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local tg=Duel.GetAttacker()
+	if chkc then return chkc==tg end
+	if chk==0 then return tg:IsOnField() and tg:IsCanBeEffectTarget(e) end
+	Duel.SetTargetCard(tg)
+	local rec=tg:GetAttack()
+	Duel.SetOperationInfo(0,CATEGORY_RECOVER,nil,0,tp,rec)
+end
+function c43250041.activate(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) and tc:IsFaceup() and tc:IsAttackable() then
+		if Duel.NegateAttack(tc) then
+			Duel.Recover(tp,tc:GetAttack(),REASON_EFFECT)
+		end
+	end
+end

--- a/script/c43452193.lua
+++ b/script/c43452193.lua
@@ -1,0 +1,34 @@
+--異次元トンネル－ミラーゲート－
+function c43452193.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_CONTROL)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c43452193.condition)
+	e1:SetTarget(c43452193.target)
+	e1:SetOperation(c43452193.activate)
+	c:RegisterEffect(e1)
+end
+function c43452193.condition(e,tp,eg,ep,ev,re,r,rp)
+	local at=Duel.GetAttackTarget()
+	return at and Duel.GetAttacker():IsControler(1-tp) and at:IsFaceup() and at:IsSetCard(0x3008)
+end
+function c43452193.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	local a=Duel.GetAttacker()
+	local at=Duel.GetAttackTarget()
+	if chk==0 then return a:IsOnField() and a:IsAbleToChangeControler()
+		and at:IsOnField() and at:IsAbleToChangeControler() end
+	local g=Group.FromCards(a,at)
+	Duel.SetTargetCard(g)
+	Duel.SetOperationInfo(0,CATEGORY_CONTROL,g,2,0,0)
+end
+function c43452193.activate(e,tp,eg,ep,ev,re,r,rp)
+	local a=Duel.GetAttacker()
+	local at=Duel.GetAttackTarget()
+	if a:IsRelateToEffect(e) and a:IsAttackable() and at:IsRelateToEffect(e) then
+		if Duel.SwapControl(a,at,RESET_PHASE+PHASE_END,1) then
+			Duel.CalculateDamage(a,at)
+		end
+	end
+end

--- a/script/c44046281.lua
+++ b/script/c44046281.lua
@@ -1,0 +1,80 @@
+--ディメンション・ゲート
+function c44046281.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_REMOVE)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetTarget(c44046281.target)
+	e1:SetOperation(c44046281.operation)
+	c:RegisterEffect(e1)
+	--send to grave
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(44046281,0))
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetCondition(c44046281.tgcon)
+	e2:SetTarget(c44046281.tgtg)
+	e2:SetOperation(c44046281.tgop)
+	c:RegisterEffect(e2)
+	--spsummon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(44046281,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetProperty(EFFECT_FLAG_DELAY)
+	e2:SetCode(EVENT_LEAVE_FIELD)
+	e2:SetCondition(c44046281.spcon)
+	e2:SetTarget(c44046281.sptg)
+	e2:SetOperation(c44046281.spop)
+	c:RegisterEffect(e2)
+end
+function c44046281.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and chkc:IsAbleToRemove() end
+	if chk==0 then return Duel.IsExistingTarget(Card.IsAbleToRemove,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+	local g=Duel.SelectTarget(tp,Card.IsAbleToRemove,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,1,0,0)
+end
+function c44046281.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if c:IsRelateToEffect(e) and tc:IsRelateToEffect(e) and Duel.Remove(tc,POS_FACEUP,REASON_EFFECT)>0 then
+		c:SetCardTarget(tc)
+	end
+end
+function c44046281.tgcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp) and Duel.GetAttackTarget()==nil
+end
+function c44046281.tgtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_TOGRAVE,e:GetHandler(),1,0,0)
+end
+function c44046281.tgop(e,tp,eg,ep,ev,re,r,rp)
+	if e:GetHandler():IsRelateToEffect(e) then
+		Duel.SendtoGrave(e:GetHandler(),REASON_EFFECT)
+	end
+end
+function c44046281.spcon(e,tp,eg,ep,ev,re,r,rp)
+	local tc=e:GetHandler():GetFirstCardTarget()
+	if tc and e:GetHandler():IsLocation(LOCATION_GRAVE) then
+		e:SetLabelObject(tc)
+		return true
+	end
+	return false
+end
+function c44046281.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local tc=e:GetLabelObject()
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and tc and tc:IsCanBeSpecialSummoned(e,0,tp,false,false) end
+	Duel.SetTargetCard(tc)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,tc,1,0,0)
+end
+function c44046281.spop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) then
+		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)
+	end
+end

--- a/script/c44095762.lua
+++ b/script/c44095762.lua
@@ -1,0 +1,29 @@
+--聖なるバリア－ミラーフォース－
+function c44095762.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_DESTROY)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c44095762.condition)
+	e1:SetTarget(c44095762.target)
+	e1:SetOperation(c44095762.activate)
+	c:RegisterEffect(e1)
+end
+function c44095762.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c44095762.filter(c)
+	return c:IsAttackPos()
+end
+function c44095762.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c44095762.filter,tp,0,LOCATION_MZONE,1,nil) end
+	local g=Duel.GetMatchingGroup(c44095762.filter,tp,0,LOCATION_MZONE,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
+end
+function c44095762.activate(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetMatchingGroup(c44095762.filter,tp,0,LOCATION_MZONE,nil)
+	if g:GetCount()>0 then
+		Duel.Destroy(g,REASON_EFFECT)
+	end
+end

--- a/script/c44509898.lua
+++ b/script/c44509898.lua
@@ -1,0 +1,41 @@
+--ピンポイント・ガード
+function c44509898.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c44509898.condition)
+	e1:SetTarget(c44509898.target)
+	e1:SetOperation(c44509898.operation)
+	c:RegisterEffect(e1)
+end
+function c44509898.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c44509898.filter(c,e,tp)
+	return c:IsLevelBelow(4) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c44509898.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c44509898.filter(chkc,e,tp) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingTarget(c44509898.filter,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectTarget(tp,c44509898.filter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
+end
+function c44509898.operation(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) and Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP_DEFENCE)~=0 then
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_INDESTRUCTABLE_BATTLE)
+		e1:SetValue(1)
+		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+		tc:RegisterEffect(e1)
+		local e2=e1:Clone()
+		e2:SetCode(EFFECT_INDESTRUCTABLE_EFFECT)
+		tc:RegisterEffect(e2)
+	end
+end

--- a/script/c4483989.lua
+++ b/script/c4483989.lua
@@ -1,0 +1,60 @@
+--モンスターBOX
+function c4483989.initial_effect(c)
+	--activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(0,TIMING_BATTLE_START)
+	e1:SetTarget(c4483989.atktg1)
+	e1:SetOperation(c4483989.atkop)
+	c:RegisterEffect(e1)
+	--dice
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(4483989,0))
+	e2:SetCategory(CATEGORY_COIN)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e2:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetCondition(c4483989.atkcon)
+	e2:SetTarget(c4483989.atktg2)
+	e2:SetOperation(c4483989.atkop)
+	c:RegisterEffect(e2)
+end
+function c4483989.atkcon(e,tp,eg,ep,ev,re,r,rp)
+	local at=Duel.GetAttackTarget()
+	return at and Duel.GetAttacker():IsControler(1-tp) and at:IsPosition(POS_FACEUP_DEFENCE)
+end
+function c4483989.atktg1(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	e:SetLabel(0)
+	local at=Duel.GetAttackTarget()
+	if Duel.CheckEvent(EVENT_ATTACK_ANNOUNCE) and Duel.GetAttacker():IsControler(1-tp)
+		and at and at:IsPosition(POS_FACEUP_DEFENCE) then
+		e:SetLabel(1)
+		Duel.GetAttacker():CreateEffectRelation(e)
+		at:CreateEffectRelation(e)
+		Duel.SetOperationInfo(0,CATEGORY_COIN,nil,0,tp,1)
+	end
+end
+function c4483989.atktg2(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	e:SetLabel(1)
+	Duel.GetAttacker():CreateEffectRelation(e)
+	Duel.GetAttackTarget():CreateEffectRelation(e)
+	Duel.SetOperationInfo(0,CATEGORY_COIN,nil,0,tp,1)
+end
+function c4483989.atkop(e,tp,eg,ep,ev,re,r,rp)
+	if e:GetLabel()==0 or not e:GetHandler():IsRelateToEffect(e) then return end
+	local a=Duel.GetAttacker()
+	local at=Duel.GetAttackTarget()
+	if a:IsFaceup() and a:IsRelateToEffect(e) and at:IsFaceup() and at:IsRelateToEffect(e) then
+		Duel.Hint(HINT_SELECTMSG,1-tp,HINTMSG_COIN)
+		local coin=Duel.SelectOption(1-tp,60,61)
+		local res=Duel.TossCoin(1-tp,1)
+		if coin~=res then
+			Duel.ChangePosition(at,POS_FACEUP_ATTACK)
+		elseif a:GetAttack()>at:GetDefence() then
+			Duel.Damage(tp,a:GetAttack()-at:GetDefence(),REASON_EFFECT)
+		end
+	end
+end

--- a/script/c44883600.lua
+++ b/script/c44883600.lua
@@ -1,0 +1,34 @@
+--ダブル・ディフェンダー
+function c44883600.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	c:RegisterEffect(e1)
+	--disable attack
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(44883600,0))
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetType(EFFECT_TYPE_TRIGGER_O+EFFECT_TYPE_FIELD)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetCountLimit(1)
+	e2:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e2:SetCondition(c44883600.condition)
+	e2:SetTarget(c44883600.target)
+	e2:SetOperation(c44883600.activate)
+	c:RegisterEffect(e2)
+end
+function c44883600.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp) and Duel.IsExistingMatchingCard(Card.IsPosition,tp,LOCATION_MZONE,0,2,nil,POS_FACEUP_DEFENCE)
+end
+function c44883600.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local tg=Duel.GetAttacker()
+	if chkc then return chkc==tg end
+	if chk==0 then return tg:IsOnField() and tg:IsCanBeEffectTarget(e) end
+	Duel.SetTargetCard(tg)
+end
+function c44883600.activate(e,tp,eg,ep,ev,re,r,rp)
+	if e:GetHandler():IsRelateToEffect(e) then
+		Duel.NegateAttack()
+	end
+end

--- a/script/c45118716.lua
+++ b/script/c45118716.lua
@@ -1,0 +1,40 @@
+--マジック・リサイクラー
+function c45118716.initial_effect(c)
+	--todeck
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(45118716,0))
+	e1:SetCategory(CATEGORY_TODECK)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetRange(LOCATION_GRAVE)
+	e1:SetCondition(c45118716.condition)
+	e1:SetCost(c45118716.cost)
+	e1:SetTarget(c45118716.target)
+	e1:SetOperation(c45118716.operation)
+	c:RegisterEffect(e1)
+end
+function c45118716.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c45118716.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsAbleToRemoveAsCost() end
+	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_COST)
+end
+function c45118716.filter(c)
+	return c:IsType(TYPE_SPELL) and c:IsAbleToDeck()
+end
+function c45118716.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_GRAVE) and c45118716.filter(chkc) end
+	if chk==0 then return Duel.IsPlayerCanDiscardDeck(tp,1)
+		and Duel.IsExistingTarget(c45118716.filter,tp,LOCATION_GRAVE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TODECK)
+	local g=Duel.SelectTarget(tp,c45118716.filter,tp,LOCATION_GRAVE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_TODECK,g,1,0,0)
+end
+function c45118716.operation(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if Duel.DiscardDeck(tp,1,REASON_EFFECT)>0 and tc:IsRelateToEffect(e) then
+		Duel.SendtoDeck(tc,nil,1,REASON_EFFECT)
+	end
+end

--- a/script/c4923662.lua
+++ b/script/c4923662.lua
@@ -1,0 +1,37 @@
+--カオス・バースト
+function c4923662.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_DESTROY+CATEGORY_DAMAGE)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c4923662.condition)
+	e1:SetCost(c4923662.cost)
+	e1:SetTarget(c4923662.target)
+	e1:SetOperation(c4923662.activate)
+	c:RegisterEffect(e1)
+end
+function c4923662.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c4923662.cost(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chk==0 then return Duel.CheckReleaseGroup(tp,nil,1,nil) end
+	local g=Duel.SelectReleaseGroup(tp,nil,1,1,nil)
+	Duel.Release(g,REASON_COST)
+end
+function c4923662.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local tg=Duel.GetAttacker()
+	if chkc then return chkc==tg end
+	if chk==0 then return tg:IsOnField() and tg:IsCanBeEffectTarget(e) end
+	Duel.SetTargetCard(tg)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,tg,1,0,0)
+end
+function c4923662.activate(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) and tc:IsAttackable() and not tc:IsStatus(STATUS_ATTACK_CANCELED)
+		and Duel.Destroy(tc,REASON_EFFECT)~=0 then
+		Duel.BreakEffect()
+		Duel.Damage(1-tp,1000,REASON_EFFECT)
+	end
+end

--- a/script/c50491121.lua
+++ b/script/c50491121.lua
@@ -1,0 +1,40 @@
+--H・C スパルタス
+function c50491121.initial_effect(c)
+	--atkup
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(50491121,0))
+	e1:SetCategory(CATEGORY_ATKCHANGE)
+	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCountLimit(1)
+	e1:SetCondition(c50491121.atkcon)
+	e1:SetTarget(c50491121.atktg)
+	e1:SetOperation(c50491121.atkop)
+	c:RegisterEffect(e1)
+end
+function c50491121.atkcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c50491121.filter(c)
+	return c:IsFaceup() and c:IsSetCard(0x6f)
+end
+function c50491121.atktg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c50491121.filter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c50491121.filter,tp,LOCATION_MZONE,0,1,e:GetHandler()) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+	Duel.SelectTarget(tp,c50491121.filter,tp,LOCATION_MZONE,0,1,1,e:GetHandler())
+end
+function c50491121.atkop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if c:IsFaceup() and c:IsRelateToEffect(e) and tc:IsFaceup() and tc:IsRelateToEffect(e) then
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_UPDATE_ATTACK)
+		e1:SetValue(tc:GetBaseAttack())
+		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_BATTLE)
+		c:RegisterEffect(e1)
+	end
+end

--- a/script/c52575195.lua
+++ b/script/c52575195.lua
@@ -1,0 +1,84 @@
+--ビビット騎士
+function c52575195.initial_effect(c)
+	--change target
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(52575195,0))
+	e1:SetCategory(CATEGORY_REMOVE+CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_QUICK_O)
+	e1:SetCode(EVENT_CHAINING)
+	e1:SetRange(LOCATION_HAND)
+	e1:SetCondition(c52575195.tgcon1)
+	e1:SetTarget(c52575195.tgtg)
+	e1:SetOperation(c52575195.tgop)
+	c:RegisterEffect(e1)
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(52575195,0))
+	e2:SetCategory(CATEGORY_REMOVE+CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e2:SetRange(LOCATION_HAND)
+	e2:SetCondition(c52575195.tgcon2)
+	e2:SetTarget(c52575195.tgtg)
+	e2:SetOperation(c52575195.tgop)
+	c:RegisterEffect(e2)
+end
+function c52575195.tgcon1(e,tp,eg,ep,ev,re,r,rp)
+	if rp==tp or not re:IsHasProperty(EFFECT_FLAG_CARD_TARGET) then return false end
+	local g=Duel.GetChainInfo(ev,CHAININFO_TARGET_CARDS)
+	if not g or g:GetCount()~=1 then return false end
+	local tc=g:GetFirst()
+	e:SetLabelObject(tc)
+	return tc:IsControler(tp) and tc:IsLocation(LOCATION_MZONE) and tc:IsFaceup()
+		and tc:IsAttribute(ATTRIBUTE_LIGHT) and tc:IsRace(RACE_BEASTWARRIOR)
+end
+function c52575195.tgcon2(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetAttacker():IsControler(tp) then return false end
+	local tc=Duel.GetAttackTarget()
+	e:SetLabelObject(tc)
+	return tc and tc:IsFaceup() and tc:IsAttribute(ATTRIBUTE_LIGHT) and tc:IsRace(RACE_BEASTWARRIOR)
+end
+function c52575195.tgtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local tc=e:GetLabelObject()
+	if chk==0 then return tc:IsAbleToRemove() and Duel.GetLocationCount(tp,LOCATION_MZONE)>=0
+		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false) end
+	Duel.SetTargetCard(tc)
+	Duel.SetOperationInfo(0,CATEGORY_REMOVE,tc,1,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
+end
+function c52575195.tgop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) and tc:IsControler(tp) and Duel.Remove(tc,tc:GetPosition(),REASON_EFFECT+REASON_TEMPORARY)~=0 then
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		e1:SetCode(EVENT_PHASE+PHASE_STANDBY)
+		e1:SetRange(LOCATION_REMOVED)
+		e1:SetCountLimit(1)
+		if Duel.GetTurnPlayer()==tp then
+			if Duel.GetCurrentPhase()==PHASE_DRAW then
+				e1:SetLabel(Duel.GetTurnCount())
+			else
+				e1:SetLabel(Duel.GetTurnCount()+2)
+			end
+		else
+			e1:SetLabel(Duel.GetTurnCount()+1)
+		end
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		e1:SetCondition(c52575195.retcon)
+		e1:SetOperation(c52575195.retop)
+		tc:RegisterEffect(e1)
+		local c=e:GetHandler()
+		if not c:IsRelateToEffect(e) then return end
+		if Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+			and c:IsCanBeSpecialSummoned(e,0,tp,false,false) then
+			Duel.SendtoGrave(c,REASON_RULE)
+		end
+	end
+end
+function c52575195.retcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetTurnCount()==e:GetLabel()
+end
+function c52575195.retop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.ReturnToField(e:GetHandler())
+	e:Reset()
+end

--- a/script/c56051648.lua
+++ b/script/c56051648.lua
@@ -1,0 +1,35 @@
+--スパイダー・エッグ
+function c56051648.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_TOKEN)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c56051648.condition)
+	e1:SetTarget(c56051648.target)
+	e1:SetOperation(c56051648.activate)
+	c:RegisterEffect(e1)
+end
+function c56051648.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp) and Duel.GetAttackTarget()==nil
+		and Duel.IsExistingMatchingCard(Card.IsRace,tp,LOCATION_GRAVE,0,3,nil,RACE_INSECT)
+end
+function c56051648.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	local tg=Duel.GetAttacker()
+	if chk==0 then return tg:IsOnField() and not Duel.IsPlayerAffectedByEffect(tp,59822133)
+		and Duel.GetLocationCount(tp,LOCATION_MZONE)>=3
+		and Duel.IsPlayerCanSpecialSummonMonster(tp,56051649,0,0x4011,100,100,1,RACE_INSECT,ATTRIBUTE_EARTH) end
+	Duel.SetOperationInfo(0,CATEGORY_TOKEN,nil,3,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,3,0,0)
+end
+function c56051648.activate(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.IsPlayerAffectedByEffect(tp,59822133) then return end
+	if Duel.NegateAttack() and Duel.GetLocationCount(tp,LOCATION_MZONE)>2
+		and Duel.IsPlayerCanSpecialSummonMonster(tp,56051649,0,0x4011,100,100,1,RACE_INSECT,ATTRIBUTE_EARTH) then
+		for i=1,3 do
+			local token=Duel.CreateToken(tp,56051649)
+			Duel.SpecialSummonStep(token,0,tp,tp,false,false,POS_FACEUP_ATTACK)
+		end
+		Duel.SpecialSummonComplete()
+	end
+end

--- a/script/c56339050.lua
+++ b/script/c56339050.lua
@@ -1,0 +1,69 @@
+--地縛神の咆哮
+function c56339050.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetTarget(c56339050.target)
+	e1:SetOperation(c56339050.operation)
+	c:RegisterEffect(e1)
+	--
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(56339050,0))
+	e2:SetCategory(CATEGORY_DESTROY+CATEGORY_DAMAGE)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e2:SetCondition(c56339050.condition2)
+	e2:SetTarget(c56339050.target2)
+	e2:SetOperation(c56339050.operation)
+	c:RegisterEffect(e2)
+end
+function c56339050.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc==Duel.GetAttacker() end
+	if chk==0 then return true end
+	if Duel.CheckEvent(EVENT_ATTACK_ANNOUNCE) then
+		local tc=Duel.GetAttacker()
+		if tc:IsControler(1-tp) and Duel.IsExistingMatchingCard(c56339050.cfilter,tp,LOCATION_MZONE,0,1,nil,tc:GetAttack()) and tc:IsOnField() and tc:IsCanBeEffectTarget(e) then
+			e:SetCategory(CATEGORY_DESTROY+CATEGORY_DAMAGE)
+			e:SetProperty(EFFECT_FLAG_CARD_TARGET)
+			Duel.SetTargetCard(tc)
+			local dam=tc:GetAttack()/2
+			Duel.SetTargetParam(dam)
+			Duel.SetOperationInfo(0,CATEGORY_DESTROY,tc,1,0,0)
+			Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,dam)
+			e:GetHandler():RegisterFlagEffect(56339050,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
+		else
+			e:SetCategory(0)
+			e:SetProperty(0)
+		end
+	end
+end
+function c56339050.operation(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() and tc:IsAttackable() then
+		local atk=tc:GetAttack()/2
+		if Duel.Destroy(tc,REASON_EFFECT)~=0 then
+			Duel.Damage(1-tp,atk,REASON_EFFECT)
+		end
+	end
+end
+function c56339050.cfilter(c,atk)
+	return c:IsFaceup() and c:IsSetCard(0x21) and c:GetAttack()>atk
+end
+function c56339050.condition2(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetAttacker()
+	return tc:IsControler(1-tp) and Duel.IsExistingMatchingCard(c56339050.cfilter,tp,LOCATION_MZONE,0,1,nil,tc:GetAttack())
+end
+function c56339050.target2(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local tc=Duel.GetAttacker()
+	if chkc then return chkc==tc end
+	if chk==0 then return e:GetHandler():GetFlagEffect(56339050)==0	and tc:IsOnField() and tc:IsCanBeEffectTarget(e) end
+	Duel.SetTargetCard(tc)
+	local dam=tc:GetAttack()/2
+	Duel.SetTargetParam(dam)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,tc,1,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,dam)
+	e:GetHandler():RegisterFlagEffect(56339050,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
+end

--- a/script/c5650082.lua
+++ b/script/c5650082.lua
@@ -1,0 +1,29 @@
+--神風のバリア －エア・フォース－
+function c5650082.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_TOHAND)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c5650082.condition)
+	e1:SetTarget(c5650082.target)
+	e1:SetOperation(c5650082.activate)
+	c:RegisterEffect(e1)
+end
+function c5650082.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c5650082.filter(c)
+	return c:IsPosition(POS_FACEUP_ATTACK) and c:IsAbleToHand()
+end
+function c5650082.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c5650082.filter,tp,0,LOCATION_MZONE,1,nil) end
+	local g=Duel.GetMatchingGroup(c5650082.filter,tp,0,LOCATION_MZONE,nil)
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,g:GetCount(),0,0)
+end
+function c5650082.activate(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetMatchingGroup(c5650082.filter,tp,0,LOCATION_MZONE,nil)
+	if g:GetCount()>0 then
+		Duel.SendtoHand(g,nil,REASON_EFFECT)
+	end
+end

--- a/script/c57115864.lua
+++ b/script/c57115864.lua
@@ -1,0 +1,42 @@
+--光子化
+function c57115864.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c57115864.condition)
+	e1:SetTarget(c57115864.target)
+	e1:SetOperation(c57115864.activate)
+	c:RegisterEffect(e1)
+end
+function c57115864.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c57115864.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local tg=Duel.GetAttacker()
+	if chkc then return chkc==tg end
+	if chk==0 then return tg:IsOnField() and tg:IsCanBeEffectTarget(e)
+		and Duel.IsExistingMatchingCard(c57115864.filter,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.SetTargetCard(tg)
+end
+function c57115864.filter(c)
+	return c:IsFaceup() and c:IsAttribute(ATTRIBUTE_LIGHT)
+end
+function c57115864.activate(e,tp,eg,ep,ev,re,r,rp)
+	Duel.NegateAttack()
+	local tc=Duel.GetFirstTarget()
+	if tc:IsFaceup() and tc:IsRelateToEffect(e) then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+		local g=Duel.SelectMatchingCard(tp,c57115864.filter,tp,LOCATION_MZONE,0,1,1,nil)
+		local ac=g:GetFirst()
+		if ac then
+			local e1=Effect.CreateEffect(e:GetHandler())
+			e1:SetType(EFFECT_TYPE_SINGLE)
+			e1:SetCode(EFFECT_UPDATE_ATTACK)
+			e1:SetValue(tc:GetAttack())
+			e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,2)
+			ac:RegisterEffect(e1)
+		end
+	end
+end

--- a/script/c59560625.lua
+++ b/script/c59560625.lua
@@ -1,0 +1,68 @@
+--シフトチェンジ
+function c59560625.initial_effect(c)
+	--change target
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(59560625,0))
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c59560625.condition1)
+	e1:SetTarget(c59560625.target1)
+	e1:SetOperation(c59560625.activate1)
+	c:RegisterEffect(e1)
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(59560625,1))
+	e2:SetType(EFFECT_TYPE_ACTIVATE)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetCode(EVENT_CHAINING)
+	e2:SetCondition(c59560625.condition2)
+	e2:SetTarget(c59560625.target2)
+	e2:SetOperation(c59560625.activate2)
+	c:RegisterEffect(e2)
+end
+function c59560625.condition1(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c59560625.filter1(c,e)
+	return c:IsCanBeEffectTarget(e)
+end
+function c59560625.target1(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return false end
+	local ag=eg:GetFirst():GetAttackableTarget()
+	local at=Duel.GetAttackTarget()
+	if chk==0 then return ag:IsExists(c59560625.filter1,1,at,e) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
+	local g=ag:FilterSelect(tp,c59560625.filter1,1,1,at,e)
+	Duel.SetTargetCard(g)
+end
+function c59560625.activate1(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) and not Duel.GetAttacker():IsImmuneToEffect(e) then
+		Duel.ChangeAttackTarget(tc)
+	end
+end
+function c59560625.condition2(e,tp,eg,ep,ev,re,r,rp)
+	if rp==tp or not re:IsHasType(EFFECT_TYPE_ACTIVATE) or not re:IsHasProperty(EFFECT_FLAG_CARD_TARGET) then return false end
+	local g=Duel.GetChainInfo(ev,CHAININFO_TARGET_CARDS)
+	if not g or g:GetCount()~=1 then return false end
+	local tc=g:GetFirst()
+	e:SetLabelObject(tc)
+	return tc:IsControler(tp) and tc:IsLocation(LOCATION_MZONE)
+end
+function c59560625.filter2(c,re,rp,tf,ceg,cep,cev,cre,cr,crp)
+	return tf(re,rp,ceg,cep,cev,cre,cr,crp,0,c)
+end
+function c59560625.target2(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local tf=re:GetTarget()
+	local res,ceg,cep,cev,cre,cr,crp=Duel.CheckEvent(re:GetCode(),true)
+	if chkc then return chkc~=e:GetLabelObject() and chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and tf(re,rp,ceg,cep,cev,cre,cr,crp,0,chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c59560625.filter2,tp,LOCATION_MZONE,0,1,e:GetLabelObject(),re,rp,tf,ceg,cep,cev,cre,cr,crp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
+	Duel.SelectTarget(tp,c59560625.filter2,tp,LOCATION_MZONE,0,1,1,e:GetLabelObject(),re,rp,tf,ceg,cep,cev,cre,cr,crp)
+end
+function c59560625.activate2(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
+	if g:GetFirst():IsRelateToEffect(e) then
+		Duel.ChangeTargetCard(ev,g)
+	end
+end

--- a/script/c60080151.lua
+++ b/script/c60080151.lua
@@ -1,0 +1,49 @@
+--好敵手の記憶
+function c60080151.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_DAMAGE+CATEGORY_REMOVE+CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c60080151.condition)
+	e1:SetTarget(c60080151.target)
+	e1:SetOperation(c60080151.activate)
+	c:RegisterEffect(e1)
+end
+function c60080151.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c60080151.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	local tg=Duel.GetAttacker()
+	if chk==0 then return tg:IsOnField() and tg:IsAbleToRemove() end
+	local dam=tg:GetAttack()
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,tp,dam)
+	Duel.SetOperationInfo(0,CATEGORY_REMOVE,tg,1,0,0)
+end
+function c60080151.activate(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetAttacker()
+	if tc and tc:IsAttackable() and not tc:IsStatus(STATUS_ATTACK_CANCELED) then
+		local dam=tc:GetAttack()
+		if Duel.Damage(tp,dam,REASON_EFFECT)>0 and Duel.Remove(tc,POS_FACEUP,REASON_EFFECT)>0 then
+			local e1=Effect.CreateEffect(e:GetHandler())
+			e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+			e1:SetCountLimit(1)
+			e1:SetCode(EVENT_PHASE+PHASE_END)
+			e1:SetCondition(c60080151.spcon)
+			e1:SetOperation(c60080151.spop)
+			e1:SetLabelObject(tc)
+			e1:SetLabel(Duel.GetTurnCount())
+			e1:SetReset(RESET_PHASE+PHASE_END+RESET_OPPO_TURN,2)
+			Duel.RegisterEffect(e1,tp)
+			tc:RegisterFlagEffect(60080151,RESET_EVENT+0x1fe0000,0,0)
+		end
+	end
+end
+function c60080151.spcon(e,tp,eg,ep,ev,re,r,rp)
+	local tc=e:GetLabelObject()
+	return Duel.GetTurnCount()~=e:GetLabel() and Duel.GetTurnPlayer()~=tp
+		and tc:GetFlagEffect(60080151)~=0 and tc:GetReasonEffect():GetHandler()==e:GetHandler()
+end
+function c60080151.spop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.SpecialSummon(e:GetLabelObject(),0,tp,tp,false,false,POS_FACEUP)
+end

--- a/script/c60312997.lua
+++ b/script/c60312997.lua
@@ -1,0 +1,56 @@
+--波動再生
+function c60312997.initial_effect(c)
+	local e1=Effect.CreateEffect(c)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c60312997.condition)
+	e1:SetTarget(c60312997.target)
+	e1:SetOperation(c60312997.operation)
+	c:RegisterEffect(e1)
+end
+function c60312997.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp) and Duel.GetAttackTarget()==nil
+		and eg:GetFirst():IsLocation(LOCATION_MZONE)
+end
+function c60312997.filter(c,lv)
+	return c:IsLevelBelow(lv) and c:IsType(TYPE_SYNCHRO) and c:IsStatus(STATUS_PROC_COMPLETE)
+end
+function c60312997.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c60312997.filter(chkc,eg:GetFirst():GetLevel()) end 
+	if chk==0 then return Duel.IsExistingTarget(c60312997.filter,tp,LOCATION_GRAVE,0,1,nil,eg:GetFirst():GetLevel()) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
+	Duel.SelectTarget(tp,c60312997.filter,tp,LOCATION_GRAVE,0,1,1,nil,eg:GetFirst():GetLevel())
+end
+function c60312997.operation(e,tp,eg,ep,ev,re,r,rp)
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_CHANGE_DAMAGE)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetReset(RESET_PHASE+PHASE_DAMAGE)
+	e1:SetTargetRange(1,0)
+	e1:SetValue(c60312997.damval)
+	Duel.RegisterEffect(e1,tp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) then
+		local e2=Effect.CreateEffect(e:GetHandler())
+		e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		e2:SetCode(EVENT_DAMAGE_STEP_END)
+		e2:SetOperation(c60312997.spop)
+		e2:SetLabelObject(tc)
+		e2:SetReset(RESET_PHASE+PHASE_DAMAGE)
+		Duel.RegisterEffect(e2,tp)
+	end
+end
+function c60312997.damval(e,re,val,r,rp,rc)
+	if r==REASON_BATTLE then
+		return val/2
+	else return val end
+end
+function c60312997.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	local tc=e:GetLabelObject()
+	if tc:IsLocation(LOCATION_GRAVE) then
+		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)
+	end
+end

--- a/script/c60417395.lua
+++ b/script/c60417395.lua
@@ -1,0 +1,87 @@
+--ダークネス・ネオスフィア
+function c60417395.initial_effect(c)
+	c:EnableReviveLimit()
+	--cannot special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
+	e1:SetValue(aux.FALSE)
+	c:RegisterEffect(e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(60417395,0))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e2:SetRange(LOCATION_HAND)
+	e2:SetCondition(c60417395.spcon)
+	e2:SetCost(c60417395.spcost)
+	e2:SetTarget(c60417395.sptg)
+	e2:SetOperation(c60417395.spop)
+	c:RegisterEffect(e2)
+	--battle indestructable
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_SINGLE)
+	e3:SetCode(EFFECT_INDESTRUCTABLE_BATTLE)
+	e3:SetValue(1)
+	c:RegisterEffect(e3)
+	--to hand
+	local e4=Effect.CreateEffect(c)
+	e4:SetDescription(aux.Stringid(60417395,1))
+	e4:SetCategory(CATEGORY_TOHAND)
+	e4:SetType(EFFECT_TYPE_IGNITION)
+	e4:SetCountLimit(1)
+	e4:SetRange(LOCATION_MZONE)
+	e4:SetTarget(c60417395.thtg)
+	e4:SetOperation(c60417395.thop)
+	c:RegisterEffect(e4)
+end
+function c60417395.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return eg:GetFirst():IsControler(1-tp)
+end
+function c60417395.cfilter1(c)
+	return c:IsFaceup() and c:IsRace(RACE_FIEND) and c:IsAbleToGraveAsCost()
+end
+function c60417395.cfilter2(c)
+	return c:IsRace(RACE_FIEND) and c:IsAbleToGraveAsCost()
+end
+function c60417395.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c60417395.cfilter1,tp,LOCATION_MZONE,0,1,nil)
+		and Duel.IsExistingMatchingCard(c60417395.cfilter2,tp,LOCATION_HAND,0,1,e:GetHandler()) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+	local g1=Duel.SelectMatchingCard(tp,c60417395.cfilter1,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+	local g2=Duel.SelectMatchingCard(tp,c60417395.cfilter2,tp,LOCATION_HAND,0,1,1,e:GetHandler())
+	g1:Merge(g2)
+	Duel.SendtoGrave(g1,REASON_COST)
+end
+function c60417395.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>-1
+		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,true,false) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
+end
+function c60417395.spop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP)~=0 then
+		c:CompleteProcedure()
+	elseif Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+		and c:IsCanBeSpecialSummoned(e,0,tp,true,false) then
+		Duel.SendtoGrave(c,REASON_RULE)
+	end
+end
+function c60417395.filter(c)
+	return c:IsFaceup() and c:IsType(TYPE_TRAP) and c:IsAbleToHand()
+end
+function c60417395.thtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chk==0 then return Duel.IsExistingTarget(c60417395.filter,tp,LOCATION_ONFIELD,0,1,nil) end
+	local g=Duel.GetMatchingGroup(c60417395.filter,tp,LOCATION_ONFIELD,0,nil)
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,g:GetCount(),0,0)
+end
+function c60417395.thop(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetMatchingGroup(c60417395.filter,tp,LOCATION_ONFIELD,0,nil)
+	if g:GetCount()>0 then
+		Duel.SendtoHand(g,nil,REASON_EFFECT)
+	end
+end

--- a/script/c60534585.lua
+++ b/script/c60534585.lua
@@ -1,0 +1,31 @@
+--闘争本能
+function c60534585.initial_effect(c)
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c60534585.condition)
+	e1:SetTarget(c60534585.target)
+	e1:SetOperation(c60534585.operation)
+	c:RegisterEffect(e1)
+end
+function c60534585.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp) and Duel.GetAttackTarget()==nil
+		and Duel.GetFieldGroupCount(tp,LOCATION_MZONE,0)==0
+end
+function c60534585.spfilter(c,e,tp)
+	return c:IsLevelBelow(4) and c:IsRace(RACE_BEAST) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c60534585.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingMatchingCard(c60534585.spfilter,tp,LOCATION_HAND,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND)
+end
+function c60534585.operation(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,c60534585.spfilter,tp,LOCATION_HAND,0,1,1,nil,e,tp)
+	if g:GetCount()~=0 then
+		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP_ATTACK)
+	end
+end

--- a/script/c62271284.lua
+++ b/script/c62271284.lua
@@ -1,0 +1,30 @@
+--ジャスティブレイク
+function c62271284.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_DESTROY)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c62271284.condition)
+	e1:SetTarget(c62271284.target)
+	e1:SetOperation(c62271284.activate)
+	c:RegisterEffect(e1)
+end
+function c62271284.condition(e,tp,eg,ep,ev,re,r,rp)
+	local at=Duel.GetAttackTarget()
+	return at and Duel.GetAttacker():IsControler(1-tp) and at:IsFaceup() and at:IsType(TYPE_NORMAL)
+end
+function c62271284.filter(c)
+	return not (c:IsFaceup() and c:IsType(TYPE_NORMAL) and c:IsAttackPos())
+end
+function c62271284.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c62271284.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
+	local g=Duel.GetMatchingGroup(c62271284.filter,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
+end
+function c62271284.activate(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetMatchingGroup(c62271284.filter,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
+	if g:GetCount()>0 then
+		Duel.Destroy(g,REASON_EFFECT)
+	end
+end

--- a/script/c63767246.lua
+++ b/script/c63767246.lua
@@ -57,7 +57,7 @@ function c63767246.disop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c63767246.cbcon(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetTurnPlayer()~=tp and Duel.GetAttackTarget()~=e:GetHandler()
+	return Duel.GetAttacker():IsControler(1-tp) and Duel.GetAttackTarget()~=e:GetHandler()
 end
 function c63767246.cbcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_COST) end

--- a/script/c65150219.lua
+++ b/script/c65150219.lua
@@ -1,0 +1,34 @@
+--機甲忍法フリーズ・ロック
+function c65150219.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c65150219.condition)
+	e1:SetOperation(c65150219.activate)
+	c:RegisterEffect(e1)
+	--pos limit
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_CANNOT_CHANGE_POSITION)
+	e2:SetProperty(EFFECT_FLAG_SET_AVAILABLE)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetTargetRange(0,LOCATION_MZONE)
+	e2:SetCondition(c65150219.poscon)
+	c:RegisterEffect(e2)
+end
+function c65150219.cfilter(c)
+	return c:IsFaceup() and c:IsSetCard(0x2b)
+end
+function c65150219.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp) and Duel.IsExistingMatchingCard(c65150219.cfilter,tp,LOCATION_MZONE,0,1,nil)
+end
+function c65150219.activate(e,tp,eg,ep,ev,re,r,rp)
+	if not e:GetHandler():IsRelateToEffect(e) then return end
+	if Duel.NegateAttack() then
+		Duel.SkipPhase(1-tp,PHASE_BATTLE,RESET_PHASE+PHASE_BATTLE,1)
+	end
+end
+function c65150219.poscon(e)
+	return Duel.IsExistingMatchingCard(c65150219.cfilter,e:GetHandlerPlayer(),LOCATION_MZONE,0,1,nil)
+end

--- a/script/c65743242.lua
+++ b/script/c65743242.lua
@@ -1,0 +1,31 @@
+--地縛霊の誘い
+function c65743242.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c65743242.condition)
+	e1:SetTarget(c65743242.target)
+	e1:SetOperation(c65743242.activate)
+	c:RegisterEffect(e1)
+end
+function c65743242.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c65743242.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then
+		local ag=eg:GetFirst():GetAttackableTarget()
+		local at=Duel.GetAttackTarget()
+		return ag:IsExists(aux.TRUE,1,at)
+	end
+end
+function c65743242.activate(e,tp,eg,ep,ev,re,r,rp)
+	local ag=eg:GetFirst():GetAttackableTarget()
+	local at=Duel.GetAttackTarget()
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
+	local g=ag:Select(tp,1,1,at)
+	local tc=g:GetFirst()
+	if tc then
+		Duel.ChangeAttackTarget(tc)
+	end
+end

--- a/script/c67095270.lua
+++ b/script/c67095270.lua
@@ -1,0 +1,22 @@
+--ディメンション・ウォール
+function c67095270.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c67095270.condition)
+	e1:SetOperation(c67095270.activate)
+	c:RegisterEffect(e1)
+end
+function c67095270.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c67095270.activate(e,tp,eg,ep,ev,re,r,rp)
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_REFLECT_BATTLE_DAMAGE)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetTargetRange(1,0)
+	e1:SetReset(RESET_PHASE+PHASE_DAMAGE)
+	Duel.RegisterEffect(e1,tp)
+end

--- a/script/c67630339.lua
+++ b/script/c67630339.lua
@@ -1,0 +1,62 @@
+--コンフュージョン・チャフ
+function c67630339.initial_effect(c)
+	--damage cal
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c67630339.condition)
+	e1:SetOperation(c67630339.operation)
+	c:RegisterEffect(e1)
+	if not c67630339.global_check then
+		c67630339.global_check=true
+		c67630339[0]=0
+		c67630339[1]=0
+		local ge1=Effect.CreateEffect(c)
+		ge1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		ge1:SetCode(EVENT_ATTACK_ANNOUNCE)
+		ge1:SetOperation(c67630339.check)
+		Duel.RegisterEffect(ge1,0)
+		local ge2=Effect.CreateEffect(c)
+		ge2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		ge2:SetCode(EVENT_ATTACK_DISABLED)
+		ge2:SetOperation(c67630339.check2)
+		Duel.RegisterEffect(ge2,0)
+		local ge3=Effect.CreateEffect(c)
+		ge3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		ge3:SetCode(EVENT_PHASE_START+PHASE_DRAW)
+		ge3:SetOperation(c67630339.clear)
+		Duel.RegisterEffect(ge3,0)
+	end
+end
+function c67630339.check(e,tp,eg,ep,ev,re,r,rp)
+	local tc=eg:GetFirst()
+	if Duel.GetAttackTarget()==nil then
+		c67630339[1-tc:GetControler()]=c67630339[1-tc:GetControler()]+1
+		Duel.GetAttacker():RegisterFlagEffect(67630339,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
+		if c67630339[1-tc:GetControler()]==1 then
+			c67630339[2]=Duel.GetAttacker()
+		end
+	end
+end
+function c67630339.check2(e,tp,eg,ep,ev,re,r,rp)
+	local tc=eg:GetFirst()
+	if tc:GetFlagEffect(67630339)~=0 and Duel.GetAttackTarget()~=nil then
+		c67630339[1-tc:GetControler()]=c67630339[1-tc:GetControler()]-1
+	end
+end
+function c67630339.clear(e,tp,eg,ep,ev,re,r,rp)
+	c67630339[0]=0
+	c67630339[1]=0
+end
+function c67630339.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp) and Duel.GetAttackTarget()==nil and c67630339[tp]==2
+		and c67630339[2]:GetFlagEffect(67630339)~=0 and Duel.GetAttacker()~=c67630339[2]
+end
+function c67630339.operation(e,tp,eg,ep,ev,re,r,rp)
+	local a=Duel.GetAttacker()
+	local d=c67630339[2]
+	if a:GetFlagEffect(67630339)~=0 and d:GetFlagEffect(67630339)~=0 
+		and a:IsAttackable() and not a:IsImmuneToEffect(e) and not d:IsImmuneToEffect(e) then
+		Duel.CalculateDamage(a,d)
+	end
+end

--- a/script/c67987611.lua
+++ b/script/c67987611.lua
@@ -1,0 +1,46 @@
+--アマゾネスの弩弓隊
+function c67987611.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_POSITION)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c67987611.condition)
+	e1:SetTarget(c67987611.target)
+	e1:SetOperation(c67987611.activate)
+	c:RegisterEffect(e1)
+end
+function c67987611.cfilter(c)
+	return c:IsFaceup() and c:IsSetCard(0x4)
+end
+function c67987611.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp) and Duel.IsExistingMatchingCard(c67987611.cfilter,tp,LOCATION_MZONE,0,1,nil)
+end
+function c67987611.filter(c)
+	return not c:IsPosition(POS_FACEUP_ATTACK)
+end
+function c67987611.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	local g=Duel.GetMatchingGroup(c67987611.filter,tp,0,LOCATION_MZONE,nil)
+	Duel.SetOperationInfo(0,CATEGORY_POSITION,g,g:GetCount(),0,0)
+end
+function c67987611.activate(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetMatchingGroup(c67987611.filter,tp,0,LOCATION_MZONE,nil)
+	Duel.ChangePosition(g,POS_FACEUP_ATTACK,POS_FACEUP_ATTACK,POS_FACEUP_ATTACK,POS_FACEUP_ATTACK,true)
+	local fg=Duel.GetMatchingGroup(Card.IsFaceup,tp,0,LOCATION_MZONE,nil)
+	local tc=fg:GetFirst()
+	while tc do
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_UPDATE_ATTACK)
+		e1:SetValue(-500)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		tc:RegisterEffect(e1)
+		local e2=Effect.CreateEffect(e:GetHandler())
+		e2:SetType(EFFECT_TYPE_SINGLE)
+		e2:SetCode(EFFECT_MUST_ATTACK)
+		e2:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+		tc:RegisterEffect(e2)
+		tc=fg:GetNext()
+	end
+end

--- a/script/c70342110.lua
+++ b/script/c70342110.lua
@@ -1,0 +1,29 @@
+--次元幽閉
+function c70342110.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_REMOVE)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c70342110.condition)
+	e1:SetTarget(c70342110.target)
+	e1:SetOperation(c70342110.activate)
+	c:RegisterEffect(e1)
+end
+function c70342110.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c70342110.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local tg=Duel.GetAttacker()
+	if chkc then return chkc==tg end
+	if chk==0 then return tg:IsOnField() and tg:IsAbleToRemove() and tg:IsCanBeEffectTarget(e) end
+	Duel.SetTargetCard(tg)
+	Duel.SetOperationInfo(0,CATEGORY_REMOVE,tg,1,0,0)
+end
+function c70342110.activate(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) and tc:IsAttackable() and not tc:IsStatus(STATUS_ATTACK_CANCELED) then
+		Duel.Remove(tc,POS_FACEUP,REASON_EFFECT)
+	end
+end

--- a/script/c72885174.lua
+++ b/script/c72885174.lua
@@ -1,0 +1,44 @@
+--フォーチュン・スリップ
+function c72885174.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_REMOVE)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c72885174.condition)
+	e1:SetTarget(c72885174.target)
+	e1:SetOperation(c72885174.activate)
+	c:RegisterEffect(e1)
+end
+function c72885174.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp) and Duel.GetAttackTarget()
+end
+function c72885174.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return false end
+	local a=Duel.GetAttacker()
+	local d=Duel.GetAttackTarget()
+	if chk==0 then return a:IsOnField() and a:IsCanBeEffectTarget(e)
+		and d:IsOnField() and d:IsAbleToRemove() and d:IsCanBeEffectTarget(e) end
+	local g=Group.FromCards(a,d)
+	Duel.SetTargetCard(g)
+	Duel.SetOperationInfo(0,CATEGORY_REMOVE,d,1,0,0)
+end
+function c72885174.activate(e,tp,eg,ep,ev,re,r,rp)
+	Duel.NegateAttack()
+	local a=Duel.GetAttacker()
+	local tc=Duel.GetAttackTarget()
+	if a:IsRelateToEffect(e) and a:IsFaceup() and tc:IsRelateToEffect(e) and Duel.Remove(tc,0,REASON_EFFECT+REASON_TEMPORARY)~=0 then
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		e1:SetCode(EVENT_PHASE+PHASE_STANDBY)
+		e1:SetReset(RESET_PHASE+PHASE_STANDBY)
+		e1:SetLabelObject(tc)
+		e1:SetCountLimit(1)
+		e1:SetOperation(c72885174.retop)
+		Duel.RegisterEffect(e1,tp)
+	end
+end
+function c72885174.retop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.ReturnToField(e:GetLabelObject())
+end

--- a/script/c75987257.lua
+++ b/script/c75987257.lua
@@ -1,0 +1,69 @@
+--隷属の鱗粉
+function c75987257.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_POSITION+CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCondition(c75987257.condition)
+	e1:SetTarget(c75987257.target)
+	e1:SetOperation(c75987257.operation)
+	c:RegisterEffect(e1)
+	--pos
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(75987257,0))
+	e2:SetType(EFFECT_TYPE_QUICK_O)
+	e2:SetCategory(CATEGORY_POSITION)
+	e2:SetCode(EVENT_FREE_CHAIN)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetCountLimit(1)
+	e2:SetCondition(c75987257.poscon)
+	e2:SetOperation(c75987257.posop)
+	c:RegisterEffect(e2)
+end
+function c75987257.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c75987257.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local tg=Duel.GetAttacker()
+	if chkc then return chkc==tg end
+	if chk==0 then return tg:IsOnField() and tg:IsCanBeEffectTarget(e) end
+	Duel.SetTargetCard(tg)
+end
+function c75987257.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsLocation(LOCATION_SZONE) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) and tc:IsAttackable() and not tc:IsStatus(STATUS_ATTACK_CANCELED) then
+		Duel.ChangePosition(tc,POS_FACEUP_DEFENCE)
+		if c:IsRelateToEffect(e) then
+			Duel.Equip(tp,c,tc)
+			c:CancelToGrave()
+			--Equip limit
+			local e1=Effect.CreateEffect(c)
+			e1:SetType(EFFECT_TYPE_SINGLE)
+			e1:SetCode(EFFECT_EQUIP_LIMIT)
+			e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+			e1:SetValue(c75987257.eqlimit)
+			e1:SetLabelObject(tc)
+			e1:SetReset(RESET_EVENT+0x1fe0000)
+			c:RegisterEffect(e1)
+		end
+	end
+end
+function c75987257.eqlimit(e,c)
+	return c==e:GetLabelObject()
+end
+function c75987257.poscon(e,tp,eg,ep,ev,re,r,rp)
+	local ph=Duel.GetCurrentPhase()
+	return ph>=PHASE_MAIN1 and ph<=PHASE_MAIN2 and e:GetHandler():GetEquipTarget()
+end
+function c75987257.posop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) then return end
+	local ec=c:GetEquipTarget()
+	if ec then
+		Duel.ChangePosition(ec,POS_FACEUP_DEFENCE,0,POS_FACEUP_ATTACK,0)
+	end
+end

--- a/script/c7617253.lua
+++ b/script/c7617253.lua
@@ -1,0 +1,48 @@
+--虹の行方
+function c7617253.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_TOHAND)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c7617253.condition)
+	e1:SetCost(c7617253.cost)
+	e1:SetTarget(c7617253.target)
+	e1:SetOperation(c7617253.activate)
+	c:RegisterEffect(e1)
+end
+function c7617253.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c7617253.costfilter(c)
+	return c:IsFaceup() and c:IsSetCard(0x1034) and c:IsAbleToGraveAsCost()
+end
+function c7617253.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c7617253.costfilter,tp,LOCATION_SZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+	local g=Duel.SelectMatchingCard(tp,c7617253.costfilter,tp,LOCATION_SZONE,0,1,1,nil)
+	Duel.SendtoGrave(g,REASON_COST)
+end
+function c7617253.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local tg=Duel.GetAttacker()
+	if chkc then return chkc==tg end
+	if chk==0 then return tg:IsOnField() and tg:IsCanBeEffectTarget(e) end
+	Duel.SetTargetCard(tg)
+end
+function c7617253.filter(c)
+	return c:IsSetCard(0x2034) and c:IsAbleToHand()
+end
+function c7617253.activate(e,tp,eg,ep,ev,re,r,rp)
+	local tg=Duel.GetAttacker()
+	if not tg:IsRelateToEffect(e) or tg:IsStatus(STATUS_ATTACK_CANCELED)
+		or not Duel.NegateAttack() then return end
+	local g=Duel.GetMatchingGroup(c7617253.filter,tp,LOCATION_DECK,0,nil)
+	if g:GetCount()>0 and Duel.SelectYesNo(tp,aux.Stringid(7617253,0)) then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+		local sg=g:Select(tp,1,1,nil)
+		Duel.BreakEffect()
+		Duel.SendtoHand(sg,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,sg)
+	end
+end

--- a/script/c78625592.lua
+++ b/script/c78625592.lua
@@ -40,7 +40,7 @@ end
 function c78625592.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 	e:SetLabel(0)
-	if Duel.CheckEvent(EVENT_ATTACK_ANNOUNCE) and tp~=Duel.GetTurnPlayer()
+	if Duel.CheckEvent(EVENT_ATTACK_ANNOUNCE) and Duel.GetAttacker():IsControler(1-tp)
 		and Duel.CheckLPCost(tp,1000) and Duel.SelectYesNo(tp,94) then
 		Duel.PayLPCost(tp,1000)
 		e:SetLabel(1)
@@ -52,7 +52,7 @@ function c78625592.operation(e,tp,eg,ep,ev,re,r,rp)
 	Duel.NegateAttack()
 end
 function c78625592.grcondition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetTurnPlayer()~=tp and (Duel.IsAbleToEnterBP() or Duel.GetCurrentPhase()>=PHASE_BATTLE)
+	return Duel.GetAttacker():IsControler(1-tp) and (Duel.IsAbleToEnterBP() or Duel.GetCurrentPhase()>=PHASE_BATTLE)
 end
 function c78625592.grcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsAbleToRemoveAsCost() end

--- a/script/c7864030.lua
+++ b/script/c7864030.lua
@@ -1,0 +1,66 @@
+--超重武者タイマ－2
+function c7864030.initial_effect(c)
+	--change battle target
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetRange(LOCATION_HAND)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCondition(c7864030.condition1)
+	e1:SetCost(c7864030.cost)
+	e1:SetTarget(c7864030.target1)
+	e1:SetOperation(c7864030.operation1)
+	c:RegisterEffect(e1)
+	--change battle target
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCountLimit(1)
+	e2:SetCondition(c7864030.condition2)
+	e2:SetOperation(c7864030.operation2)
+	c:RegisterEffect(e2)
+	--indes
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_SINGLE)
+	e3:SetCode(EFFECT_INDESTRUCTABLE_BATTLE)
+	e3:SetValue(1)
+	c:RegisterEffect(e3)
+end
+function c7864030.condition1(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp) and not Duel.IsExistingMatchingCard(Card.IsType,tp,LOCATION_GRAVE,0,1,nil,TYPE_SPELL+TYPE_TRAP)
+end
+function c7864030.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsAbleToGraveAsCost() end
+	Duel.SendtoGrave(e:GetHandler(),REASON_COST)
+end
+function c7864030.filter(c)
+	return c:IsFaceup() and c:IsSetCard(0x9a)
+end
+function c7864030.target1(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c7864030.filter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c7864030.filter,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
+	Duel.SelectTarget(tp,c7864030.filter,tp,LOCATION_MZONE,0,1,1,nil)
+end
+function c7864030.operation1(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) then
+		local at=Duel.GetAttacker()
+		if at:IsAttackable() and not at:IsImmuneToEffect(e) and not tc:IsImmuneToEffect(e) then
+			Duel.CalculateDamage(at,tc)
+		end
+	end
+end
+function c7864030.condition2(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp) and Duel.GetAttackTarget()~=e:GetHandler()
+end
+function c7864030.operation2(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsRelateToEffect(e) then
+		local at=Duel.GetAttacker()
+		if at:IsAttackable() and not at:IsImmuneToEffect(e) then
+			Duel.CalculateDamage(at,c)
+		end
+	end
+end

--- a/script/c82340056.lua
+++ b/script/c82340056.lua
@@ -1,0 +1,65 @@
+--栄誉の贄
+function c82340056.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c82340056.condition)
+	e1:SetTarget(c82340056.target)
+	e1:SetOperation(c82340056.activate)
+	c:RegisterEffect(e1)
+end
+function c82340056.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetLP(tp)<=3000 and Duel.GetAttacker():IsControler(1-tp) and Duel.GetAttackTarget()==nil
+end
+function c82340056.filter(c)
+	return c:IsSetCard(0x21) and c:IsAbleToHand()
+end
+function c82340056.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,59822133)
+		and Duel.GetLocationCount(tp,LOCATION_MZONE)>1
+		and Duel.IsPlayerCanSpecialSummonMonster(tp,82340057,0,0x4011,0,0,1,RACE_ROCK,ATTRIBUTE_EARTH)
+		and Duel.IsExistingMatchingCard(c82340056.filter,tp,LOCATION_DECK,0,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_TOKEN,nil,2,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,2,0,0)
+end
+function c82340056.activate(e,tp,eg,ep,ev,re,r,rp)
+	if not Duel.NegateAttack() then return end
+	if Duel.IsPlayerAffectedByEffect(tp,59822133) then return end
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<2
+		or not Duel.IsPlayerCanSpecialSummonMonster(tp,82340057,0,0x4011,0,0,1,RACE_ROCK,ATTRIBUTE_EARTH) then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local g=Duel.SelectMatchingCard(tp,c82340056.filter,tp,LOCATION_DECK,0,1,1,nil)
+	if g:GetCount()==0 then return end
+	Duel.BreakEffect()
+	Duel.SendtoHand(g,nil,REASON_EFFECT)
+	Duel.ConfirmCards(1-tp,g)
+	Duel.ShuffleHand(tp)
+	for i=1,2 do
+		local token=Duel.CreateToken(tp,82340057)
+		Duel.SpecialSummonStep(token,0,tp,tp,false,false,POS_FACEUP)
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_UNRELEASABLE_NONSUM)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		e1:SetValue(1)
+		token:RegisterEffect(e1,true)
+		local e2=Effect.CreateEffect(e:GetHandler())
+		e2:SetType(EFFECT_TYPE_SINGLE)
+		e2:SetCode(EFFECT_UNRELEASABLE_SUM)
+		e2:SetReset(RESET_EVENT+0x1fe0000)
+		e2:SetValue(c82340056.sumlimit)
+		token:RegisterEffect(e2,true)
+		local e3=Effect.CreateEffect(e:GetHandler())
+		e3:SetType(EFFECT_TYPE_SINGLE)
+		e3:SetCode(EFFECT_CANNOT_BE_SYNCHRO_MATERIAL)
+		e3:SetReset(RESET_EVENT+0x1fe0000)
+		e3:SetValue(1)
+		token:RegisterEffect(e3,true)
+	end
+	Duel.SpecialSummonComplete()
+end
+function c82340056.sumlimit(e,c)
+	return not c:IsSetCard(0x21)
+end

--- a/script/c8279188.lua
+++ b/script/c8279188.lua
@@ -1,0 +1,73 @@
+--デプス・アミュレット
+function c8279188.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetTarget(c8279188.target1)
+	e1:SetOperation(c8279188.activate)
+	c:RegisterEffect(e1)
+	--negate
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(8279188,1))
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetType(EFFECT_TYPE_QUICK_O)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e2:SetCondition(c8279188.condition)
+	e2:SetTarget(c8279188.target2)
+	e2:SetOperation(c8279188.activate)
+	c:RegisterEffect(e2)
+end
+function c8279188.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c8279188.target1(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local tg=Duel.GetAttacker()
+	if chkc then return chkc==tg end
+	if chk==0 then return true end
+	e:GetHandler():SetTurnCounter(0)
+	--destroy
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e1:SetCode(EVENT_PHASE+PHASE_END)
+	e1:SetCountLimit(1)
+	e1:SetRange(LOCATION_SZONE)
+	e1:SetCondition(c8279188.descon)
+	e1:SetOperation(c8279188.desop)
+	e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END+RESET_OPPO_TURN,3)
+	e:GetHandler():RegisterEffect(e1)
+	if Duel.CheckEvent(EVENT_ATTACK_ANNOUNCE) and tp~=Duel.GetTurnPlayer() and tg:IsOnField() and tg:IsCanBeEffectTarget(e)
+		and Duel.GetFieldGroupCount(tp,LOCATION_HAND,0)~=0 and Duel.SelectYesNo(tp,aux.Stringid(8279188,0)) then
+		e:SetProperty(EFFECT_FLAG_CARD_TARGET)
+		Duel.SetTargetCard(tg)
+	else e:SetProperty(0) end
+end
+function c8279188.target2(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local tg=Duel.GetAttacker()
+	if chkc then return chkc==tg end
+	if chk==0 then return not e:GetHandler():IsStatus(STATUS_CHAINING)
+		and Duel.GetFieldGroupCount(tp,LOCATION_HAND,0)~=0 and tg:IsOnField() and tg:IsCanBeEffectTarget(e) end
+	Duel.SetTargetCard(tg)
+end
+function c8279188.activate(e,tp,eg,ep,ev,re,r,rp)
+	if not e:GetHandler():IsRelateToEffect(e) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() and Duel.GetFieldGroupCount(tp,LOCATION_HAND,0)~=0 then
+		Duel.DiscardHand(tp,Card.IsDiscardable,1,1,REASON_EFFECT+REASON_DISCARD)
+		Duel.NegateAttack()
+	end
+end
+function c8279188.descon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetTurnPlayer()~=tp
+end
+function c8279188.desop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local ct=c:GetTurnCounter()
+	ct=ct+1
+	c:SetTurnCounter(ct)
+	if ct==3 then
+		Duel.Destroy(c,REASON_EFFECT)
+	end
+end

--- a/script/c8706701.lua
+++ b/script/c8706701.lua
@@ -31,7 +31,7 @@ function c8706701.initial_effect(c)
 end
 
 function c8706701.thcon1(e,tp,eg,ep,ev,re,r,rp)
-  return Duel.GetTurnPlayer()~=tp
+  return Duel.GetAttacker():IsControler(1-tp)
 end
 function c8706701.thcost(e,tp,eg,ep,ev,re,r,rp,chk)
   if chk==0 then return e:GetHandler():IsAbleToGraveAsCost() end

--- a/script/c88482761.lua
+++ b/script/c88482761.lua
@@ -1,0 +1,94 @@
+--ダイスロール・バトル
+function c88482761.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c88482761.condition)
+	e1:SetTarget(c88482761.target)
+	e1:SetOperation(c88482761.operation)
+	c:RegisterEffect(e1)
+	--
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(88482761,0))
+	e2:SetType(EFFECT_TYPE_QUICK_O)
+	e2:SetRange(LOCATION_GRAVE)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetCode(EVENT_FREE_CHAIN)
+	e2:SetCondition(c88482761.atkcon)
+	e2:SetCost(c88482761.atkcost)
+	e2:SetTarget(c88482761.atktg)
+	e2:SetOperation(c88482761.atkop)
+	c:RegisterEffect(e2)
+end
+function c88482761.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c88482761.rmfilter1(c,e,tp)
+	return c:IsSetCard(0x2016) and c:IsAbleToRemove()
+		and Duel.IsExistingMatchingCard(c88482761.spfilter,tp,LOCATION_EXTRA,0,1,nil,e,tp,c:GetOriginalLevel())
+end
+function c88482761.rmfilter2(c,lv)
+	return c:IsSetCard(0x2016) and c:IsType(TYPE_TUNER) and c:IsAbleToRemove() and c:GetOriginalLevel()==lv
+end
+function c88482761.spfilter(c,e,tp,lv)
+	return c:IsType(TYPE_SYNCHRO) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+		and Duel.IsExistingMatchingCard(c88482761.rmfilter2,tp,LOCATION_HAND,0,1,nil,c:GetLevel()-lv)
+end
+function c88482761.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c88482761.rmfilter1(chkc,e,tp) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingTarget(c88482761.rmfilter1,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+	local g=Duel.SelectTarget(tp,c88482761.rmfilter1,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
+	Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,1,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
+end
+function c88482761.operation(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if not tc:IsRelateToEffect(e) then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,c88482761.spfilter,tp,LOCATION_EXTRA,0,1,1,nil,e,tp,tc:GetOriginalLevel())
+	if g:GetCount()>0 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+		local rg=Duel.SelectMatchingCard(tp,c88482761.rmfilter2,tp,LOCATION_HAND,0,1,1,nil,g:GetFirst():GetLevel()-tc:GetOriginalLevel())
+		rg:AddCard(tc)
+		if Duel.Remove(rg,POS_FACEUP,REASON_EFFECT)==2 then
+			Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
+		end
+	end
+end
+function c88482761.atkcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetTurnPlayer()~=tp and Duel.GetCurrentPhase()==PHASE_BATTLE_STEP
+end
+function c88482761.atkcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsAbleToRemoveAsCost() end
+	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_COST)
+end
+function c88482761.atkfilter(c)
+	return c:IsType(TYPE_SYNCHRO) and c:IsPosition(POS_FACEUP_ATTACK)
+end
+function c88482761.atktg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return false end
+	if chk==0 then return Duel.IsExistingTarget(c88482761.atkfilter,tp,LOCATION_MZONE,0,1,nil)
+		and Duel.IsExistingTarget(c88482761.atkfilter,tp,0,LOCATION_MZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
+	Duel.SelectTarget(tp,c88482761.atkfilter,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
+	local g2=Duel.SelectTarget(tp,c88482761.atkfilter,tp,0,LOCATION_MZONE,1,1,nil)
+	e:SetLabelObject(g2:GetFirst())
+end
+function c88482761.atkop(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(Card.IsRelateToEffect,nil,e)
+	if g:GetCount()==2 then
+		local c1=g:GetFirst()
+		local c2=g:GetNext()
+		if c1~=e:GetLabelObject() then c1,c2=c2,c1 end
+		if c1:IsControler(1-tp) and c1:IsPosition(POS_FACEUP_ATTACK) and not c1:IsImmuneToEffect(e)
+			and c2:IsControler(tp) then
+			Duel.CalculateDamage(c1,c2,true)
+		end
+	end
+end

--- a/script/c89040386.lua
+++ b/script/c89040386.lua
@@ -1,0 +1,30 @@
+--BF－バックフラッシュ
+function c89040386.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_DESTROY)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c89040386.condition)
+	e1:SetTarget(c89040386.target)
+	e1:SetOperation(c89040386.activate)
+	c:RegisterEffect(e1)
+end
+function c89040386.cfilter(c)
+	return c:IsSetCard(0x33) and c:IsType(TYPE_MONSTER)
+end
+function c89040386.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp) and Duel.GetAttackTarget()==nil
+		and Duel.IsExistingMatchingCard(c89040386.cfilter,tp,LOCATION_GRAVE,0,5,nil)
+end
+function c89040386.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetFieldGroupCount(tp,0,LOCATION_MZONE)>0 end
+	local g=Duel.GetFieldGroup(tp,0,LOCATION_MZONE)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
+end
+function c89040386.activate(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetFieldGroup(tp,0,LOCATION_MZONE)
+	if g:GetCount()>0 then
+		Duel.Destroy(g,REASON_EFFECT)
+	end
+end

--- a/script/c89041555.lua
+++ b/script/c89041555.lua
@@ -1,0 +1,31 @@
+--生贄の抱く爆弾
+function c89041555.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_DESTROY+CATEGORY_DAMAGE)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c89041555.condition)
+	e1:SetTarget(c89041555.target)
+	e1:SetOperation(c89041555.activate)
+	c:RegisterEffect(e1)
+end
+function c89041555.condition(e,tp,eg,ep,ev,re,r,rp)
+	local tc=eg:GetFirst()
+	return tc:IsControler(1-tp) and bit.band(tc:GetSummonType(),SUMMON_TYPE_ADVANCE)==SUMMON_TYPE_ADVANCE
+end
+function c89041555.filter(c)
+	return c:IsAttackPos()
+end
+function c89041555.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c89041555.filter,tp,0,LOCATION_MZONE,1,nil) end
+	local g=Duel.GetMatchingGroup(c89041555.filter,tp,0,LOCATION_MZONE,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,1000)
+end
+function c89041555.activate(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetMatchingGroup(c89041555.filter,tp,0,LOCATION_MZONE,nil)
+	if g:GetCount()>0 and Duel.Destroy(g,REASON_EFFECT)>0 then
+		Duel.Damage(1-tp,1000,REASON_EFFECT)
+	end
+end

--- a/script/c9201964.lua
+++ b/script/c9201964.lua
@@ -1,0 +1,26 @@
+--D－フォーチュン
+function c9201964.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c9201964.condition)
+	e1:SetCost(c9201964.cost)
+	e1:SetOperation(c9201964.activate)
+	c:RegisterEffect(e1)
+end
+function c9201964.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp) and Duel.GetAttackTarget()==nil
+end
+function c9201964.cfilter(c)
+	return c:IsSetCard(0xc008) and c:IsAbleToRemoveAsCost()
+end
+function c9201964.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c9201964.cfilter,tp,LOCATION_GRAVE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+	local g=Duel.SelectMatchingCard(tp,c9201964.cfilter,tp,LOCATION_GRAVE,0,1,1,nil)
+	Duel.Remove(g,POS_FACEUP,REASON_COST)
+end
+function c9201964.activate(e,tp,eg,ep,ev,re,r,rp)
+	Duel.SkipPhase(1-tp,PHASE_BATTLE,RESET_PHASE+PHASE_BATTLE,1)
+end

--- a/script/c92773018.lua
+++ b/script/c92773018.lua
@@ -1,0 +1,70 @@
+--サイバネティック・ヒドゥン・テクノロジー
+function c92773018.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetTarget(c92773018.target1)
+	e1:SetOperation(c92773018.activate)
+	c:RegisterEffect(e1)
+	--destroy
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(92773018,0))
+	e2:SetCategory(CATEGORY_DESTROY)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetType(EFFECT_TYPE_QUICK_O)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e2:SetCondition(c92773018.condition)
+	e2:SetCost(c92773018.cost)
+	e2:SetTarget(c92773018.target2)
+	e2:SetOperation(c92773018.activate)
+	c:RegisterEffect(e2)
+end
+function c92773018.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c92773018.cfilter(c)
+	return c:IsFaceup() and (c:IsCode(70095154) or aux.IsMaterialListCode(c,70095154)) and c:IsAbleToGraveAsCost()
+end
+function c92773018.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c92773018.cfilter,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+	local g=Duel.SelectMatchingCard(tp,c92773018.cfilter,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SendtoGrave(g,REASON_COST)
+end
+function c92773018.target1(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc==Duel.GetAttacker() end
+	if chk==0 then return true end
+	local tg=Duel.GetAttacker()
+	if Duel.CheckEvent(EVENT_ATTACK_ANNOUNCE) and Duel.GetAttacker():IsControler(1-tp)
+		and Duel.IsExistingMatchingCard(c92773018.cfilter,tp,LOCATION_MZONE,0,1,nil)
+		and tg:IsOnField() and tg:IsCanBeEffectTarget(e)
+		and Duel.SelectYesNo(tp,aux.Stringid(92773018,1)) then
+		e:SetCategory(CATEGORY_DESTROY)
+		e:SetProperty(EFFECT_FLAG_CARD_TARGET)
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+		local g=Duel.SelectMatchingCard(tp,c92773018.cfilter,tp,LOCATION_MZONE,0,1,1,nil)
+		Duel.SendtoGrave(g,REASON_COST)
+		Duel.SetTargetCard(tg)
+		Duel.SetOperationInfo(0,CATEGORY_DESTROY,tg,1,0,0)
+	else
+		e:SetCategory(0)
+		e:SetProperty(0)
+	end
+end
+function c92773018.target2(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local tg=Duel.GetAttacker()
+	if chkc then return chkc==tg end
+	if chk==0 then return not e:GetHandler():IsStatus(STATUS_CHAINING)
+		and tg:IsOnField() and tg:IsCanBeEffectTarget(e) end
+	Duel.SetTargetCard(tg)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,tg,1,0,0)
+end
+function c92773018.activate(e,tp,eg,ep,ev,re,r,rp)
+	if not e:GetHandler():IsRelateToEffect(e) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and tc:IsAttackable() and not tc:IsStatus(STATUS_ATTACK_CANCELED) then
+		Duel.Destroy(tc,REASON_EFFECT)
+	end
+end

--- a/script/c92854392.lua
+++ b/script/c92854392.lua
@@ -1,0 +1,43 @@
+--立ちはだかる強敵
+function c92854392.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c92854392.condition)
+	e1:SetTarget(c92854392.target)
+	e1:SetOperation(c92854392.activate)
+	c:RegisterEffect(e1)
+end
+function c92854392.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c92854392.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local at=Duel.GetAttackTarget()
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and chkc:IsFaceup() and chkc~=at end
+	if chk==0 then return Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,0,1,at) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+	Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_MZONE,0,1,1,at)
+end
+function c92854392.activate(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) then
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_FIELD)
+		e1:SetCode(EFFECT_MUST_ATTACK)
+		e1:SetTargetRange(0,LOCATION_MZONE)
+		e1:SetReset(RESET_PHASE+PHASE_BATTLE)
+		Duel.RegisterEffect(e1,tp)
+		local e2=e1:Clone()
+		e2:SetCode(EFFECT_MUST_ATTACK_MONSTER)
+		Duel.RegisterEffect(e2,tp)
+		local e3=Effect.CreateEffect(e:GetHandler())
+		e3:SetType(EFFECT_TYPE_SINGLE)
+		e3:SetCode(EFFECT_MUST_BE_ATTACKED)
+		e3:SetValue(1)
+		e3:SetReset(RESET_PHASE+PHASE_BATTLE+RESET_EVENT+0x1fc0000)
+		tc:RegisterEffect(e3,true)
+		Duel.ChangeAttackTarget(tc)
+	end
+end

--- a/script/c92870717.lua
+++ b/script/c92870717.lua
@@ -1,0 +1,62 @@
+--魔装戦士 ドラゴノックス
+function c92870717.initial_effect(c)
+	--pendulum summon
+	aux.EnablePendulumAttribute(c)
+	--
+	local e2=Effect.CreateEffect(c)
+	e2:SetCategory(CATEGORY_DESTROY)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e2:SetRange(LOCATION_PZONE)
+	e2:SetCondition(c92870717.descon)
+	e2:SetTarget(c92870717.destg)
+	e2:SetOperation(c92870717.desop)
+	c:RegisterEffect(e2)
+	--spsummon
+	local e3=Effect.CreateEffect(c)
+	e3:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e3:SetType(EFFECT_TYPE_IGNITION)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e3:SetCountLimit(1)
+	e3:SetCost(c92870717.spcost)
+	e3:SetTarget(c92870717.sptg)
+	e3:SetOperation(c92870717.spop)
+	c:RegisterEffect(e3)
+end
+function c92870717.descon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c92870717.destg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,e:GetHandler(),1,0,0)
+end
+function c92870717.desop(e,tp,eg,ep,ev,re,r,rp)
+	if not e:GetHandler():IsRelateToEffect(e) then return end
+	if Duel.Destroy(e:GetHandler(),REASON_EFFECT)~=0 then
+		Duel.SkipPhase(1-tp,PHASE_BATTLE,RESET_PHASE+PHASE_BATTLE,1)
+	end
+end
+function c92870717.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsDiscardable,tp,LOCATION_HAND,0,1,nil) end
+	Duel.DiscardHand(tp,Card.IsDiscardable,1,1,REASON_DISCARD+REASON_COST,nil)
+end
+function c92870717.spfilter(c,e,tp)
+	return c:IsAttackBelow(2000) and c:IsRace(RACE_WARRIOR+RACE_SPELLCASTER)
+		and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENCE)
+end
+function c92870717.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c92870717.spfilter(chkc,e,tp) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingTarget(c92870717.spfilter,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectTarget(tp,c92870717.spfilter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
+end
+function c92870717.spop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) then
+		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEDOWN_DEFENCE)
+		Duel.ConfirmCards(1-tp,tc)
+	end
+end

--- a/script/c94861297.lua
+++ b/script/c94861297.lua
@@ -11,7 +11,7 @@ function c94861297.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c94861297.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer()
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c94861297.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetFieldGroupCount(tp,0,LOCATION_HAND)>0 end

--- a/script/c96008713.lua
+++ b/script/c96008713.lua
@@ -1,0 +1,36 @@
+--マジックアーム・シールド
+function c96008713.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_CONTROL)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c96008713.condition)
+	e1:SetTarget(c96008713.target)
+	e1:SetOperation(c96008713.activate)
+	c:RegisterEffect(e1)
+end
+function c96008713.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp) and Duel.GetFieldGroupCount(tp,LOCATION_MZONE,0)>0
+end
+function c96008713.filter(c)
+	return c:IsFaceup() and c:IsControlerCanBeChanged()
+end
+function c96008713.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local atr=Duel.GetAttacker()
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and c96008713.filter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c96008713.filter,tp,0,LOCATION_MZONE,1,atr) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_CONTROL)
+	local g=Duel.SelectTarget(tp,c96008713.filter,tp,0,LOCATION_MZONE,1,1,atr)
+	Duel.SetOperationInfo(0,CATEGORY_CONTROL,g,1,0,0)
+end
+function c96008713.activate(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	local a=Duel.GetAttacker()
+	if tc:IsRelateToEffect(e) and tc:IsFaceup() and Duel.GetControl(tc,tp,PHASE_BATTLE,1)~=0 then
+		if a:IsAttackable() and not a:IsImmuneToEffect(e) then
+			Duel.CalculateDamage(a,tc)
+		end
+	end
+end

--- a/script/c96355986.lua
+++ b/script/c96355986.lua
@@ -1,0 +1,32 @@
+--ホーリージャベリン
+function c96355986.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_RECOVER)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c96355986.condition)
+	e1:SetTarget(c96355986.target)
+	e1:SetOperation(c96355986.activate)
+	c:RegisterEffect(e1)
+end
+function c96355986.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c96355986.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local tg=Duel.GetAttacker()
+	if chkc then return chkc==tg end
+	if chk==0 then return tg:IsOnField() and tg:IsCanBeEffectTarget(e) end
+	Duel.SetTargetCard(tg)
+	local rec=tg:GetAttack()
+	Duel.SetTargetParam(rec)
+	Duel.SetOperationInfo(0,CATEGORY_RECOVER,nil,0,tp,rec)
+end
+function c96355986.activate(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) and tc:IsFaceup() then
+		local rec=tc:GetAttack()
+		Duel.Recover(tp,rec,REASON_EFFECT)
+	end
+end

--- a/script/c96427353.lua
+++ b/script/c96427353.lua
@@ -1,0 +1,35 @@
+--機甲忍者アクア
+function c96427353.initial_effect(c)
+	--disable attack
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(96427353,0))
+	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetRange(LOCATION_GRAVE)
+	e1:SetCondition(c96427353.condition)
+	e1:SetCost(c96427353.cost)
+	e1:SetTarget(c96427353.target)
+	e1:SetOperation(c96427353.operation)
+	c:RegisterEffect(e1)
+end
+function c96427353.cfilter(c)
+	return c:IsSetCard(0x2b) and c:IsType(TYPE_MONSTER)
+end
+function c96427353.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp) and Duel.GetAttackTarget()==nil
+		and Duel.IsExistingMatchingCard(c96427353.cfilter,tp,LOCATION_GRAVE,0,1,e:GetHandler())
+end
+function c96427353.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsAbleToRemoveAsCost() end
+	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_COST)
+end
+function c96427353.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local tg=Duel.GetAttacker()
+	if chkc then return chkc==tg end
+	if chk==0 then return tg:IsOnField() and tg:IsCanBeEffectTarget(e) end
+	Duel.SetTargetCard(tg)
+end
+function c96427353.operation(e,tp,eg,ep,ev,re,r,rp)
+	Duel.NegateAttack()
+end

--- a/script/c96700602.lua
+++ b/script/c96700602.lua
@@ -1,0 +1,37 @@
+--波動障壁
+function c96700602.initial_effect(c)
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_POSITION+CATEGORY_DAMAGE)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c96700602.condition)
+	e1:SetCost(c96700602.cost)
+	e1:SetTarget(c96700602.target)
+	e1:SetOperation(c96700602.operation)
+	c:RegisterEffect(e1)
+end
+function c96700602.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c96700602.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.CheckReleaseGroup(tp,Card.IsType,1,nil,TYPE_SYNCHRO) end
+	local g=Duel.SelectReleaseGroup(tp,Card.IsType,1,1,nil,TYPE_SYNCHRO)
+	Duel.Release(g,REASON_COST)
+end
+function c96700602.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsAttackPos,tp,0,LOCATION_MZONE,1,nil) end
+	local tc=eg:GetFirst()
+	if tc:IsLocation(LOCATION_MZONE) then
+		Duel.SetTargetCard(tc)
+		Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,tc:GetDefence())
+	end
+end
+function c96700602.operation(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	local g=Duel.GetMatchingGroup(Card.IsAttackPos,tp,0,LOCATION_MZONE,nil)
+	if Duel.ChangePosition(g,POS_FACEUP_DEFENCE,POS_FACEDOWN_DEFENCE,0,0)~=0 then
+		if tc:IsRelateToEffect(e) and tc:IsFaceup() then
+			Duel.Damage(1-tp,tc:GetDefence(),REASON_EFFECT)
+		end
+	end
+end

--- a/script/c97705809.lua
+++ b/script/c97705809.lua
@@ -1,0 +1,30 @@
+--スーパーチャージ
+function c97705809.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_DRAW)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c97705809.condition)
+	e1:SetTarget(c97705809.target)
+	e1:SetOperation(c97705809.activate)
+	c:RegisterEffect(e1)
+end
+function c97705809.cfilter(c)
+	return c:IsFacedown() or not c:IsSetCard(0x16) or not c:IsRace(RACE_MACHINE)
+end
+function c97705809.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp) and Duel.GetFieldGroupCount(tp,LOCATION_MZONE,0)~=0
+		and not Duel.IsExistingMatchingCard(c97705809.cfilter,tp,LOCATION_MZONE,0,1,nil)
+end
+function c97705809.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsPlayerCanDraw(tp,2) end
+	Duel.SetTargetPlayer(tp)
+	Duel.SetTargetParam(2)
+	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,2)
+end
+function c97705809.activate(e,tp,eg,ep,ev,re,r,rp)
+	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+	Duel.Draw(p,d,REASON_EFFECT)
+end

--- a/script/c97970833.lua
+++ b/script/c97970833.lua
@@ -1,0 +1,36 @@
+--ラスト・リゾート
+function c97970833.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c97970833.condition)
+	e1:SetTarget(c97970833.target)
+	e1:SetOperation(c97970833.activate)
+	c:RegisterEffect(e1)
+end
+function c97970833.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c97970833.filter(c,tp)
+	return c:IsCode(34487429) and c:GetActivateEffect():IsActivatable(tp)
+end
+function c97970833.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c97970833.filter,tp,LOCATION_DECK,0,1,nil,tp) end
+end
+function c97970833.activate(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstMatchingCard(c97970833.filter,tp,LOCATION_DECK,0,nil,tp)
+	if tc then
+		local fc=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
+		if fc then
+			Duel.SendtoGrave(fc,REASON_RULE)
+			Duel.BreakEffect()
+		end
+		Duel.MoveToField(tc,tp,tp,LOCATION_SZONE,POS_FACEUP,true)
+		fc=Duel.GetFieldCard(1-tp,LOCATION_SZONE,5)
+		if fc and fc:IsFaceup() and Duel.IsPlayerCanDraw(1-tp,1) and Duel.SelectYesNo(tp,aux.Stringid(97970833,0)) then
+			Duel.Draw(1-tp,1,REASON_EFFECT)
+		end
+		Duel.RaiseEvent(tc,EVENT_CHAIN_SOLVED,tc:GetActivateEffect(),0,tp,tp,Duel.GetCurrentChain())
+	end
+end

--- a/script/c98427577.lua
+++ b/script/c98427577.lua
@@ -1,0 +1,31 @@
+--くず鉄のかかし 
+function c98427577.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c98427577.condition)
+	e1:SetTarget(c98427577.target)
+	e1:SetOperation(c98427577.activate)
+	c:RegisterEffect(e1)
+end
+function c98427577.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c98427577.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local tg=Duel.GetAttacker()
+	if chkc then return chkc==tg end
+	if chk==0 then return tg:IsOnField() and tg:IsCanBeEffectTarget(e) end
+	Duel.SetTargetCard(tg)
+end
+function c98427577.activate(e,tp,eg,ep,ev,re,r,rp)
+	Duel.NegateAttack()
+	local c=e:GetHandler()
+	if c:IsRelateToEffect(e) and c:IsCanTurnSet() then
+		Duel.BreakEffect()
+		c:CancelToGrave()
+		Duel.ChangePosition(c,POS_FACEDOWN)
+		Duel.RaiseEvent(c,EVENT_SSET,e,REASON_EFFECT,tp,tp,0)
+	end
+end


### PR DESCRIPTION
### List of Fixed Cards:

Malevolent Catastrophe
Prepare to Strike Back
Chaos Burst
Storming Mirror Force
Rainbow Path
Superheavy Samurai Blowtorch
Depth Amulet
D - Fortune
Kid Guard
Koa'ki Meiru Shield
Negate Attack
Archfiend Interceptor
Dark Mirror Force
Radiant Mirror Force
Jam Defender
A Hero Emerges
Fairy Box
Battle Break
Insect Neglect
Changing Destiny
Poseidon Wave
Security Orb
Lucky Punch
Roulette Spider
Kunai with Chain
Relieve Monster
Ordeal of a Traveler
Sandstorm Mirror Force
Draining Shield
Mirror Gate
Dimension Gate
Mirror Force
Pinpoint Guard
Double Defender
Spell Recycler
Heroic Challenger
Vivid Knight
Spider Egg
Roar of the Earthbound
Lumenize
Shift
Memory of an Adversary
Reanimation Wave
Darkness Neosphere
Battle Instinct
Justi-Break
Armor Ninjitsu Art of Freezing
Call of the Earthbound
Dimension Wall
Confusion Chaff
Amazoness Archers
Dimensional Prison
Slip of Fortune
Butterflyoke
Offering to the Immortals
Dice-Roll Battle
Blackwing - Backlash
Blast Held by a Tribute
Cybernetic Hidden Technology
Staunch Defender
Dragonox, the Empowered Warrior
Magical Arm Shield
Enchanted Javelin
Aqua Armor Ninja
Barrier Wave
Supercharge
Last Resort
Scrap-Iron Scarecrow
Red Mirror
Performapal Fireflux
Dark Sanctuary
Number 38: Hope Harbinger Dragon Titanic Galaxy
Spiritual Swords of Revealing Light
The Forceful Checkpoint
